### PR TITLE
Fix dropOpen reset and added dllexport

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1659,6 +1659,7 @@ RAYGUIDEF int GuiDropdownBox(Rectangle bounds, const char **text, int count, int
             {
                 if (CheckCollisionPointRec(mousePoint, (Rectangle){ bounds.x, bounds.y + i*bounds.height, bounds.width, bounds.height })) active = i - 1;
             }
+            dropOpen = false;
         }
     }
     //--------------------------------------------------------------------

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -108,14 +108,14 @@
     #include "raylib.h"
 #endif
 
-#define RAYGUI_STATIC
+// #define RAYGUI_STATIC
 #ifdef RAYGUI_STATIC
     #define RAYGUIDEF static            // Functions just visible to module including this file
 #else
     #ifdef __cplusplus
         #define RAYGUIDEF extern "C"    // Functions visible from other files (no name mangling of functions in C++)
     #else
-        #define RAYGUIDEF extern        // Functions visible from other files
+        #define RAYGUIDEF __declspec(dllexport) extern        // Functions visible from other files
     #endif
 #endif
 


### PR DESCRIPTION
Reset dropOpen when dropdown closed. Forgot to add in previous commit