### PR TITLE
Fixed crash when editing textbox at non-end pos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 
 !tools/rGuiLayout/release/win32/rguilayout.exe
 !tools/rGuiStyler/release/win32/rguistyler.exe
+
+.vscode/

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2334,7 +2334,7 @@ RAYGUIDEF bool GuiTextBox(Rectangle bounds, char *text, int textSize, bool editM
                             int startIdx = GuiTextBoxGetByteIndex(text, 0, 0, guiTextBoxState.cursor);
                             int endIdx = startIdx + sz;
                             
-                            if (endIdx <= textSize)
+                            if (endIdx <= textSize && length < textSize - 1)
                             {
                                 guiTextBoxState.cursor++;
                                 guiTextBoxState.select = -1;


### PR DESCRIPTION
I was encountering a crash when editing a textbox by adding more characters than the char[] could handle. While attempting this from the end of the textbox it would simply not enter the characters, adding the new characters from a position before the end of the array causes the error.

This is the fix I've implemented.