### PR TITLE
fix textbox bug

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2709,6 +2709,7 @@ RAYGUIDEF bool GuiTextBox(Rectangle bounds, char *text, int textSize, bool editM
                     {
                         text[keyCount] = (char)key;
                         keyCount++;
+                        text[keyCount] = '\0';
                     }
                 }
             }


### PR DESCRIPTION
Fixes bug in GuiTextBox if you type and the text buffer has non-zero data after the null terminator (which it might have!). Now adding a null terminator after the typed text.