### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_library(raygui INTERFACE)
 
 file(GLOB sources *.h)
-set(RAYGUI_HEADERS, ${sources})
+set(RAYGUI_HEADERS ${sources})
 
 install(FILES
-	${RAYGUI_HEADERS} DESTINATION include/
+	${RAYGUI_HEADERS} DESTINATION include
 )
 
 target_include_directories(raygui INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/)


### PR DESCRIPTION
Remove comma after RAYGUI_HEADERS or make install will not install the headers because RAYGUI_HEADERS is not set. ", " is an unreported syntactic error.