### PR TITLE
Build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.11)
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 project(raygui C)
+
+find_package(raylib QUIET)
+
+if(NOT raylib_FOUND)
+  message(WARNING "RayLib not found. Building from source.")
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindRaylib.cmake)
+endif()
 
 # Config options
 option(BUILD_EXAMPLES "Build the examples." ON)

--- a/cmake/FindRaylib.cmake
+++ b/cmake/FindRaylib.cmake
@@ -1,17 +1,14 @@
-find_package(raylib 3.0.0 QUIET)
-if (NOT raylib_FOUND)
-  include(FetchContent)
-  FetchContent_Declare(
-    raylib
-    GIT_REPOSITORY https://github.com/raysan5/raylib.git
-    GIT_TAG 6a8b1079c13b7d5e1bddc0ecc86ad7e16fc2556d
-  )
-  FetchContent_GetProperties(raylib)
-  if (NOT raylib_POPULATED) # Have we downloaded raylib yet?
-    set(FETCHCONTENT_QUIET NO)
-    FetchContent_Populate(raylib)
-    set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
-    set(BUILD_GAMES    OFF CACHE BOOL "" FORCE) # or games
-    add_subdirectory(${raylib_SOURCE_DIR} ${raylib_BINARY_DIR})
-  endif()
+include(FetchContent)
+FetchContent_Declare(
+  raylib
+  GIT_REPOSITORY https://github.com/raysan5/raylib.git
+  GIT_TAG 6a8b1079c13b7d5e1bddc0ecc86ad7e16fc2556d
+)
+FetchContent_GetProperties(raylib)
+if (NOT raylib_POPULATED) # Have we downloaded raylib yet?
+  set(FETCHCONTENT_QUIET NO)
+  FetchContent_Populate(raylib)
+  set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE) # don't build the supplied examples
+  set(BUILD_GAMES    OFF CACHE BOOL "" FORCE) # or games
+  add_subdirectory(${raylib_SOURCE_DIR} ${raylib_BINARY_DIR})
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach(example_source ${example_sources})
   # Setup the example
   add_executable(${example_name} ${example_source})
 
-  target_link_libraries(${example_name} LINK_INTERFACE_LIBRARIES ${raylib_LIBRARIES} raygui)
+  target_link_libraries(${example_name} ${raylib_LIBRARIES} raygui)
 
   string(REGEX MATCH ".*/.*/" resources_dir ${example_source})
   string(APPEND resources_dir "resources")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(Raylib)
-
 # Get the sources together
 set(example_dirs
 	custom_file_dialog
@@ -36,7 +34,7 @@ foreach(example_source ${example_sources})
   # Setup the example
   add_executable(${example_name} ${example_source})
 
-  target_link_libraries(${example_name} PUBLIC raylib raygui)
+  target_link_libraries(${example_name} LINK_INTERFACE_LIBRARIES ${raylib_LIBRARIES} raygui)
 
   string(REGEX MATCH ".*/.*/" resources_dir ${example_source})
   string(APPEND resources_dir "resources")


### PR DESCRIPTION
The build system has problems and a build is never completed with cmake. The problem is with `CMAKE_MODULE_PATH` being assigned to `cmake` in which `FindRaylib.cmake` recursively calls itself looking for raylib until it times out. To confirm this put `message("FindRaylib called")` at the immediate beginning of the script. Also because `CMAKE_MODULE_PATH` being set causes cmake to not look into already installed `raylib` in `\usr\local` (this variable takes priority). I have updated most parts and now the build works as expected. It should build `raylib` as expected if it can't find a previous local installation.