### PR TITLE
Update for missing example target

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -352,7 +352,9 @@ EXAMPLES = \
     image_raw_importer/image_raw_importer \
     portable_window/portable_window \
     scroll_panel/gui_scroll_panel \
-    text_box_selection/gui_text_box
+    text_box_selection/textbox_extended_demo \
+    text_editor/text_editor \
+    property_list/property_list
 
 CURRENT_MAKEFILE = $(lastword $(MAKEFILE_LIST))
 


### PR DESCRIPTION
text_box_selection
text_editor
property_list

were missing from the Makefile target. 