### PR TITLE
Handle CRLF line endings reading fontFileName.

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2784,7 +2784,7 @@ void GuiLoadStyle(const char *fileName)
                         int fontSize = 0;
                         char charmapFileName[256] = { 0 };
                         char fontFileName[256] = { 0 };
-                        sscanf(buffer, "f %d %s %[^\n]s", &fontSize, charmapFileName, fontFileName);
+                        sscanf(buffer, "f %d %s %[^\r\n]s", &fontSize, charmapFileName, fontFileName);
 
                         Font font = { 0 };
 


### PR DESCRIPTION
If you have a style file with CRLF line endings and specify a font file on a system that expects LF line endings, then the font file will fail to load with an error such as...

```
WARNING: FILEIO: [./assets/terminal/Mecha.ttf
] Failed to open file
```

...because it sees the CR as part of the name.

Adding '\r' to the negated scanset for sscanf() fixes the issue.