### PR TITLE
Fixed bug with stuck slide bars in scroll_panel example

### DIFF
--- a/examples/scroll_panel/gui_scroll_panel.c
+++ b/examples/scroll_panel/gui_scroll_panel.c
@@ -78,8 +78,8 @@ int main()
             
             showContentArea = GuiCheckBox((Rectangle){ 565, 80, 20, 20 }, "SHOW CONTENT AREA", showContentArea);
                 
-            panelContentRec.width = GuiSliderBar((Rectangle){ 590, 385, 145, 15}, "WIDTH", TextFormat("%i", (int)panelContentRec.width), 1, 600, true);
-            panelContentRec.height = GuiSliderBar((Rectangle){ 590, 410, 145, 15 }, "HEIGHT", TextFormat("%i", (int)panelContentRec.height), 1, 400, true);
+            panelContentRec.width = GuiSliderBar((Rectangle){ 590, 385, 145, 15}, "WIDTH", TextFormat("%i", (int)panelContentRec.width), panelContentRec.width, 1, 600);
+            panelContentRec.height = GuiSliderBar((Rectangle){ 590, 410, 145, 15 }, "HEIGHT", TextFormat("%i", (int)panelContentRec.height), panelContentRec.height, 1, 400);
             
         EndDrawing();
         //----------------------------------------------------------------------------------


### PR DESCRIPTION
Scroll_panel example (https://github.com/raysan5/raygui/tree/master/examples/scroll_panel) uses two slide bars that should allow change of content area dimensions, but they were stuck and either set to the maximum value, or 1 while clicked (see the gif1).

![acBwOD9msB](https://user-images.githubusercontent.com/29927094/108928853-2c1e4600-7643-11eb-8fde-c2193bab1355.gif)


Correcting arguments taken by `GuiSliderBar()` functions that correspond to `panelContentRec` dimensions fixed the bug and now slide bars work as intended (see gif2):.
![UCGwmIYDhI](https://user-images.githubusercontent.com/29927094/108929913-32152680-7645-11eb-8d8b-7e29d45939b0.gif)


It's kinda weird tho how there was `bool` argument in the `GuiSliderBar()` functions which definition doesn't use any argument of that type - was an older version of this function using `bool` type argument and it was left there causing a bug?