### PR TITLE
Move cplusplus curly brace and RAYGUI_H endifs above implementation

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -496,6 +496,12 @@ RAYGUIDEF bool GuiCheckIconPixel(int iconId, int x, int y);     // Check icon pi
 #endif
 
 
+#if defined(__cplusplus)
+}            // Prevents name mangling of functions
+#endif
+
+#endif // RAYGUI_H
+
 /***********************************************************************************
 *
 *   RAYGUI IMPLEMENTATION
@@ -3673,9 +3679,3 @@ static const char *CodepointToUtf8(int codepoint, int *byteLength)
 #endif      // RAYGUI_STANDALONE
 
 #endif      // RAYGUI_IMPLEMENTATION
-
-#if defined(__cplusplus)
-}            // Prevents name mangling of functions
-#endif
-
-#endif // RAYGUI_H


### PR DESCRIPTION
Related https://github.com/raysan5/raygui/pull/121

It is moved above to be same as in `physac` or `rlgl` modules. I don't program C++ so I don't know if that is what we need and whether we should edit `physac`, `rlgl` and any other modules instead. But I parse these files to generate Nim language bindings so I'd like them to be as close as possible.

https://github.com/raysan5/raylib/blob/master/src/rlgl.h#L630
https://github.com/raysan5/raylib/blob/master/src/physac.h#L233