### PR TITLE
Move declarations of GetCodepoint() and CodepointToUTF8()

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1235,6 +1235,9 @@ static const char **TextSplit(const char *text, char delimiter, int *count);    
 static int TextToInteger(const char *text);         // Get integer value from text
 
 static void DrawRectangleGradientV(int posX, int posY, int width, int height, Color color1, Color color2);  // Draw rectangle vertical gradient
+
+static int GetCodepoint(const char *text, int *bytesProcessed); // Get next codepoint in a UTF-8 encoded text
+static const char *CodepointToUTF8(int codepoint, int *byteSize); // Encode codepoint into UTF-8 text (char array size returned as parameter)
 //-------------------------------------------------------------------------------
 
 #endif      // RAYGUI_STANDALONE
@@ -1252,9 +1255,6 @@ static void GuiDrawRectangle(Rectangle rec, int borderWidth, Color borderColor, 
 static const char **GuiTextSplit(const char *text, int *count, int *textRow);   // Split controls text into multiple strings
 static Vector3 ConvertHSVtoRGB(Vector3 hsv);                    // Convert color data from HSV to RGB
 static Vector3 ConvertRGBtoHSV(Vector3 rgb);                    // Convert color data from RGB to HSV
-
-static const char *CodepointToUTF8(int codepoint, int *byteSize); // Encode codepoint into UTF-8 text (char array size returned as parameter)
-static int GetCodepoint(const char *text, int *bytesProcessed); // Get next codepoint in a UTF-8 encoded text
 
 //----------------------------------------------------------------------------------
 // Gui Setup Functions Definition


### PR DESCRIPTION
This pull request resolves the declaration conflict errors of  `GetCodepoint()` and `CodepointToUTF8()` [which are already implemented in raylib](https://github.com/raysan5/raylib/blob/master/src/raylib.h#L1338).

```
In file included from amber/src/editor.c:21:
amber/src/external/raygui.h:1256:12: error: static declaration of ‘GetCodepoint’ follows non-static declaration
 1256 | static int GetCodepoint(const char *text, int *bytesProcessed); // Get next codepoint in a UTF-8 encoded text
      |            ^~~~~~~~~~~~
In file included from amber/include/amber.h:23,
                 from amber/src/editor.c:18:
amber/lib/raylib/raylib.h:1338:11: note: previous declaration of ‘GetCodepoint’ was here
 1338 | RLAPI int GetCodepoint(const char *text, int *bytesProcessed);        // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
      |           ^~~~~~~~~~~~
In file included from amber/src/editor.c:21:
amber/src/external/raygui.h:1257:20: error: static declaration of ‘CodepointToUTF8’ follows non-static declaration
 1257 | static const char *CodepointToUTF8(int codepoint, int *byteSize); // Encode codepoint into UTF-8 text (char array size returned as parameter)
      |                    ^~~~~~~~~~~~~~~
In file included from amber/include/amber.h:23,
                 from amber/src/editor.c:18:
amber/lib/raylib/raylib.h:1339:19: note: previous declaration of ‘CodepointToUTF8’ was here
 1339 | RLAPI const char *CodepointToUTF8(int codepoint, int *byteSize);    // Encode one codepoint into UTF-8 byte array (array length returned as parameter)
      |                   ^~~~~~~~~~~~~~~
```