### PR TITLE
Fixed bounds check in `GuiValueBox()`

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2184,6 +2184,9 @@ bool GuiValueBox(Rectangle bounds, const char *text, int *value, int minValue, i
 
             if (valueHasChanged) *value = TextToInteger(textValue);
 
+            if (*value > maxValue) *value = maxValue;
+            else if (*value < minValue) *value = minValue;
+
             if (IsKeyPressed(KEY_ENTER) || (!CheckCollisionPointRec(mousePoint, bounds) && IsMouseButtonPressed(MOUSE_LEFT_BUTTON))) pressed = true;
         }
         else


### PR DESCRIPTION
Fixed bounds check so that out of bounds values don't persist until the next call to `GuiValueBox()`.
#164 is fixed by this PR.