### PR TITLE
Fixed Spinner control bounds check error

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2079,6 +2079,14 @@ bool GuiSpinner(Rectangle bounds, const char *text, int *value, int minValue, in
         }
     }
 
+#if defined(RAYGUI_NO_RICONS)
+    if (GuiButton(leftButtonBound, "<")) tempValue--;
+    if (GuiButton(rightButtonBound, ">")) tempValue++;
+#else
+    if (GuiButton(leftButtonBound, GuiIconText(RICON_ARROW_LEFT_FILL, NULL))) tempValue--;
+    if (GuiButton(rightButtonBound, GuiIconText(RICON_ARROW_RIGHT_FILL, NULL))) tempValue++;
+#endif
+
     if (!editMode)
     {
         if (tempValue < minValue) tempValue = minValue;
@@ -2098,13 +2106,7 @@ bool GuiSpinner(Rectangle bounds, const char *text, int *value, int minValue, in
     GuiSetStyle(BUTTON, BORDER_WIDTH, GuiGetStyle(SPINNER, BORDER_WIDTH));
     GuiSetStyle(BUTTON, TEXT_ALIGNMENT, GUI_TEXT_ALIGN_CENTER);
 
-#if defined(RAYGUI_NO_RICONS)
-    if (GuiButton(leftButtonBound, "<")) tempValue--;
-    if (GuiButton(rightButtonBound, ">")) tempValue++;
-#else
-    if (GuiButton(leftButtonBound, GuiIconText(RICON_ARROW_LEFT_FILL, NULL))) tempValue--;
-    if (GuiButton(rightButtonBound, GuiIconText(RICON_ARROW_RIGHT_FILL, NULL))) tempValue++;
-#endif
+
 
     GuiSetStyle(BUTTON, TEXT_ALIGNMENT, tempTextAlign);
     GuiSetStyle(BUTTON, BORDER_WIDTH, tempBorderWidth);


### PR DESCRIPTION
The bounds check occurred before the `GuiButton`s for the increment and decrement feature of the `Spinner` control which meant using the buttons when the spinner value was at the `minValue` or `maxValue` and incremented or decremented past the min or max would not be resolved until the next time the `Spinner` control was called in the code, likely on the next iteration of a program loop. This caused an array index out of bounds issue in my codebase.

#163 is fixed by this PR.