### PR TITLE
Fix examples build for macOS

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -319,7 +319,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),OSX)
         # Libraries for OSX 10.9 desktop compiling
         # NOTE: Required packages: libopenal-dev libegl1-mesa-dev
-        LDLIBS = -lraylib -framework OpenGL -framework OpenAL -framework Cocoa
+        LDLIBS = -lraylib -framework OpenGL -framework Cocoa -framework IOKit -framework CoreAudio -framework CoreVideo
     endif
     ifeq ($(PLATFORM_OS),BSD)
         # Libraries for FreeBSD, OpenBSD, NetBSD, DragonFly desktop compiling


### PR DESCRIPTION
Updating frameworks for macOS to match latest raylib examples Makefile https://github.com/raysan5/raylib/blob/a940f41b4bfb681c9cbed9e95d1b73fee64d5bb8/examples/Makefile#L357

Related https://github.com/raysan5/raylib/pull/1022