### PR TITLE
add text parameter to GuiScrollPanel examples

### DIFF
--- a/examples/controls_test_suite/controls_test_suite.c
+++ b/examples/controls_test_suite/controls_test_suite.c
@@ -197,7 +197,7 @@ int main()
             progressValue = GuiProgressBar((Rectangle){ 320, 460, 200, 20 }, NULL, NULL, progressValue, 0, 1);
 
             // NOTE: View rectangle could be used to perform some scissor test
-            Rectangle view = GuiScrollPanel((Rectangle){ 560, 25, 100, 160 }, (Rectangle){ 560, 25, 200, 400 }, &viewScroll);
+            Rectangle view = GuiScrollPanel((Rectangle){ 560, 25, 100, 160 }, "", (Rectangle){ 560, 25, 200, 400 }, &viewScroll);
 
             GuiStatusBar((Rectangle){ 0, GetScreenHeight() - 20, GetScreenWidth(), 20 }, "This is a status bar");
 

--- a/examples/scroll_panel/gui_scroll_panel.c
+++ b/examples/scroll_panel/gui_scroll_panel.c
@@ -13,7 +13,7 @@
 *       gcc -o $(NAME_PART).exe $(FILE_NAME) -I../../src -lraylib -lopengl32 -lgdi32 -std=c99
 *
 *   COMPILATION (Linux - gcc):
-*       gcc -o $(NAME_PART) $(FILE_NAME) -I../../src -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -std=c99 
+*       gcc -o $(NAME_PART) $(FILE_NAME) -I../../src -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -std=c99
 *
 *   LICENSE: zlib/libpng
 *
@@ -40,16 +40,16 @@ int main()
     const int screenHeight = 450;
 
     InitWindow(screenWidth, screenHeight, "raygui - GuiScrollPanel()");
-    
+
     Rectangle panelRec = { 20, 40, 200, 150 };
     Rectangle panelContentRec = {0, 0, 340, 340 };
     Vector2 panelScroll = { 99, -20 };
-    
+
     bool showContentArea = true;
-    
+
     SetTargetFPS(60);
     //---------------------------------------------------------------------------------------
-    
+
     // Main game loop
     while (!WindowShouldClose())    // Detect window close button or ESC key
     {
@@ -61,26 +61,26 @@ int main()
         // Draw
         //----------------------------------------------------------------------------------
         BeginDrawing();
-            
+
             ClearBackground(RAYWHITE);
-            
+
             DrawText(TextFormat("[%f, %f]", panelScroll.x, panelScroll.y), 4, 4, 20, RED);
-            
-            Rectangle view = GuiScrollPanel(panelRec, panelContentRec, &panelScroll);
-            
+
+            Rectangle view = GuiScrollPanel(panelRec, "", panelContentRec, &panelScroll);
+
             BeginScissorMode(view.x, view.y, view.width, view.height);
                 GuiGrid((Rectangle){panelRec.x + panelScroll.x, panelRec.y + panelScroll.y, panelContentRec.width, panelContentRec.height}, 16, 3);
             EndScissorMode();
-            
+
             if (showContentArea) DrawRectangle(panelRec.x + panelScroll.x, panelRec.y + panelScroll.y, panelContentRec.width, panelContentRec.height, Fade(RED, 0.1));
-            
+
             DrawStyleEditControls();
-            
+
             showContentArea = GuiCheckBox((Rectangle){ 565, 80, 20, 20 }, "SHOW CONTENT AREA", showContentArea);
-                
+
             panelContentRec.width = GuiSliderBar((Rectangle){ 590, 385, 145, 15}, "WIDTH", TextFormat("%i", (int)panelContentRec.width), panelContentRec.width, 1, 600);
             panelContentRec.height = GuiSliderBar((Rectangle){ 590, 410, 145, 15 }, "HEIGHT", TextFormat("%i", (int)panelContentRec.height), panelContentRec.height, 1, 400);
-            
+
         EndDrawing();
         //----------------------------------------------------------------------------------
     }
@@ -99,35 +99,35 @@ static void DrawStyleEditControls(void)
     // ScrollPanel style controls
     //----------------------------------------------------------
     GuiGroupBox((Rectangle){ 550, 170, 220, 205 }, "SCROLLBAR STYLE");
-    
+
     int style = GuiGetStyle(SCROLLBAR, BORDER_WIDTH);
     GuiLabel((Rectangle){ 555, 195, 110, 10 }, "BORDER_WIDTH");
     GuiSpinner((Rectangle){ 670, 190, 90, 20 }, NULL, &style, 0, 6, false);
     GuiSetStyle(SCROLLBAR, BORDER_WIDTH, style);
-    
+
     style = GuiGetStyle(SCROLLBAR, ARROWS_SIZE);
     GuiLabel((Rectangle){ 555, 220, 110, 10 }, "ARROWS_SIZE");
     GuiSpinner((Rectangle){ 670, 215, 90, 20 }, NULL, &style, 4, 14, false);
     GuiSetStyle(SCROLLBAR, ARROWS_SIZE, style);
-    
+
     style = GuiGetStyle(SCROLLBAR, SLIDER_PADDING);
     GuiLabel((Rectangle){ 555, 245, 110, 10 }, "SLIDER_PADDING");
     GuiSpinner((Rectangle){ 670, 240, 90, 20 }, NULL, &style, 0, 14, false);
     GuiSetStyle(SCROLLBAR, SLIDER_PADDING, style);
-    
+
     style = GuiCheckBox((Rectangle){ 565, 280, 20, 20 }, "ARROWS_VISIBLE", GuiGetStyle(SCROLLBAR, ARROWS_VISIBLE));
     GuiSetStyle(SCROLLBAR, ARROWS_VISIBLE, style);
-    
+
     style = GuiGetStyle(SCROLLBAR, SLIDER_PADDING);
     GuiLabel((Rectangle){ 555, 325, 110, 10 }, "SLIDER_PADDING");
     GuiSpinner((Rectangle){ 670, 320, 90, 20 }, NULL, &style, 0, 14, false);
     GuiSetStyle(SCROLLBAR, SLIDER_PADDING, style);
-    
+
     style = GuiGetStyle(SCROLLBAR, SLIDER_WIDTH);
     GuiLabel((Rectangle){ 555, 350, 110, 10 }, "SLIDER_WIDTH");
     GuiSpinner((Rectangle){ 670, 345, 90, 20 }, NULL, &style, 2, 100, false);
     GuiSetStyle(SCROLLBAR, SLIDER_WIDTH, style);
-    
+
     const char *text = GuiGetStyle(LISTVIEW, SCROLLBAR_SIDE) == SCROLLBAR_LEFT_SIDE? "SCROLLBAR: LEFT" : "SCROLLBAR: RIGHT";
     style = GuiToggle((Rectangle){ 560, 110, 200, 35 }, text, GuiGetStyle(LISTVIEW, SCROLLBAR_SIDE));
     GuiSetStyle(LISTVIEW, SCROLLBAR_SIDE, style);
@@ -136,12 +136,12 @@ static void DrawStyleEditControls(void)
     // ScrollBar style controls
     //----------------------------------------------------------
     GuiGroupBox((Rectangle){ 550, 20, 220, 135 }, "SCROLLPANEL STYLE");
-    
+
     style = GuiGetStyle(LISTVIEW, SCROLLBAR_WIDTH);
     GuiLabel((Rectangle){ 555, 35, 110, 10 }, "SCROLLBAR_WIDTH");
     GuiSpinner((Rectangle){ 670, 30, 90, 20 }, NULL, &style, 6, 30, false);
     GuiSetStyle(LISTVIEW, SCROLLBAR_WIDTH, style);
-    
+
     style = GuiGetStyle(DEFAULT, BORDER_WIDTH);
     GuiLabel((Rectangle){ 555, 60, 110, 10 }, "BORDER_WIDTH");
     GuiSpinner((Rectangle){ 670, 55, 90, 20 }, NULL, &style, 0, 20, false);

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -556,47 +556,8 @@ RAYGUIAPI void GuiSetIconData(int iconId, unsigned int *data);  // Set icon bit 
 RAYGUIAPI void GuiSetIconPixel(int iconId, int x, int y);       // Set icon pixel value
 RAYGUIAPI void GuiClearIconPixel(int iconId, int x, int y);     // Clear icon pixel value
 RAYGUIAPI bool GuiCheckIconPixel(int iconId, int x, int y);     // Check icon pixel value
-#endif
 
-#if defined(__cplusplus)
-}            // Prevents name mangling of functions
-#endif
-
-#endif // RAYGUI_H
-
-/***********************************************************************************
-*
-*   RAYGUI IMPLEMENTATION
-*
-************************************************************************************/
-
-#if defined(RAYGUI_IMPLEMENTATION)
-
-#include <stdio.h>              // Required for: FILE, fopen(), fclose(), fprintf(), feof(), fscanf(), vsprintf() [GuiLoadStyle(), GuiLoadIcons()]
-#include <stdlib.h>             // Required for: malloc(), calloc(), free() [GuiLoadStyle(), GuiLoadIcons()]
-#include <string.h>             // Required for: strlen() [GuiTextBox(), GuiTextBoxMulti(), GuiValueBox()], memset(), memcpy()
-#include <stdarg.h>             // Required for: va_list, va_start(), vfprintf(), va_end() [TextFormat()]
-#include <math.h>               // Required for: roundf() [GuiColorPicker()]
-
-#ifdef __cplusplus
-    #define RAYGUI_CLITERAL(name) name
-#else
-    #define RAYGUI_CLITERAL(name) (name)
-#endif
-
-#if !defined(RAYGUI_NO_ICONS) && !defined(RAYGUI_CUSTOM_ICONS)
-
-// Embedded raygui icons, no external file provided
-#define RAYGUI_ICON_SIZE               16       // Size of icons (squared)
-#define RAYGUI_ICON_MAX_ICONS         256       // Maximum number of icons
-#define RAYGUI_ICON_MAX_NAME_LENGTH    32       // Maximum length of icon name id
-
-// Icons data is defined by bit array (every bit represents one pixel)
-// Those arrays are stored as unsigned int data arrays, so every array
-// element defines 32 pixels (bits) of information
-// Number of elemens depend on RAYGUI_ICON_SIZE (by default 16x16 pixels)
-#define RAYGUI_ICON_DATA_ELEMENTS   (RAYGUI_ICON_SIZE*RAYGUI_ICON_SIZE/32)
-
+#if !defined(RAYGUI_CUSTOM_ICONS)
 //----------------------------------------------------------------------------------
 // Icons enumeration
 //----------------------------------------------------------------------------------
@@ -858,6 +819,48 @@ typedef enum {
     RAYGUI_ICON_254                      = 254,
     RAYGUI_ICON_255                      = 255,
 } guiIconName;
+#endif
+
+#endif
+
+#if defined(__cplusplus)
+}            // Prevents name mangling of functions
+#endif
+
+#endif // RAYGUI_H
+
+/***********************************************************************************
+*
+*   RAYGUI IMPLEMENTATION
+*
+************************************************************************************/
+
+#if defined(RAYGUI_IMPLEMENTATION)
+
+#include <stdio.h>              // Required for: FILE, fopen(), fclose(), fprintf(), feof(), fscanf(), vsprintf() [GuiLoadStyle(), GuiLoadIcons()]
+#include <stdlib.h>             // Required for: malloc(), calloc(), free() [GuiLoadStyle(), GuiLoadIcons()]
+#include <string.h>             // Required for: strlen() [GuiTextBox(), GuiTextBoxMulti(), GuiValueBox()], memset(), memcpy()
+#include <stdarg.h>             // Required for: va_list, va_start(), vfprintf(), va_end() [TextFormat()]
+#include <math.h>               // Required for: roundf() [GuiColorPicker()]
+
+#ifdef __cplusplus
+    #define RAYGUI_CLITERAL(name) name
+#else
+    #define RAYGUI_CLITERAL(name) (name)
+#endif
+
+#if !defined(RAYGUI_NO_ICONS) && !defined(RAYGUI_CUSTOM_ICONS)
+
+// Embedded raygui icons, no external file provided
+#define RAYGUI_ICON_SIZE               16       // Size of icons (squared)
+#define RAYGUI_ICON_MAX_ICONS         256       // Maximum number of icons
+#define RAYGUI_ICON_MAX_NAME_LENGTH    32       // Maximum length of icon name id
+
+// Icons data is defined by bit array (every bit represents one pixel)
+// Those arrays are stored as unsigned int data arrays, so every array
+// element defines 32 pixels (bits) of information
+// Number of elemens depend on RAYGUI_ICON_SIZE (by default 16x16 pixels)
+#define RAYGUI_ICON_DATA_ELEMENTS   (RAYGUI_ICON_SIZE*RAYGUI_ICON_SIZE/32)
 
 //----------------------------------------------------------------------------------
 // Icons data for all gui possible icons (allocated on data segment by default)
@@ -3288,7 +3291,7 @@ Vector2 GuiGrid(Rectangle bounds, float spacing, int subdivs)
 
     // Draw control
     //--------------------------------------------------------------------
-    
+
     // TODO: Draw background panel?
 
     switch (state)
@@ -3870,7 +3873,7 @@ static const char *GetTextIcon(const char *text, int *iconId)
 static void GuiDrawText(const char *text, Rectangle bounds, int alignment, Color tint)
 {
     #define TEXT_VALIGN_PIXEL_OFFSET(h)  ((int)h%2)     // Vertical alignment for pixel perfect
-    
+
     #if !defined(RAYGUI_ICON_TEXT_PADDING)
         #define RAYGUI_ICON_TEXT_PADDING   4
     #endif
@@ -3882,7 +3885,7 @@ static void GuiDrawText(const char *text, Rectangle bounds, int alignment, Color
 
         // Get text position depending on alignment and iconId
         //---------------------------------------------------------------------------------
-        
+
 
         Vector2 position = { bounds.x, bounds.y };
 
@@ -4213,7 +4216,7 @@ const char **TextSplit(const char *text, char delimiter, int *count)
     // all used memory is static... it has some limitations:
     //      1. Maximum number of possible split strings is set by RAYGUI_TEXTSPLIT_MAX_ELEMENTS
     //      2. Maximum size of text to split is RAYGUI_TEXTSPLIT_MAX_TEXT_SIZE
-    
+
     #if !defined(RAYGUI_TEXTSPLIT_MAX_ELEMENTS)
         #define RAYGUI_TEXTSPLIT_MAX_ELEMENTS        128
     #endif


### PR DESCRIPTION
GuiScrollPanel was changed to take a text parameter, but the examples weren't updated. These two failed to build without the change.