### PR TITLE
Added 'saveFileMode' option to file dialog state

### DIFF
--- a/examples/custom_file_dialog/gui_file_dialog.h
+++ b/examples/custom_file_dialog/gui_file_dialog.h
@@ -78,6 +78,8 @@ typedef struct {
 
     int prevFilesListActive;
 
+    bool saveFileMode;
+
 } GuiFileDialogState;
 
 #ifdef __cplusplus
@@ -350,7 +352,7 @@ void GuiFileDialog(GuiFileDialogState *state)
                         }
                     }
                 }
-                else
+                else if (!state->saveFileMode)
                 {
                     strcpy(state->fileNameText, state->fileNameTextCopy);
                 }


### PR DESCRIPTION
In the Custom File Dialog example, currently it's hard to use it to create a new file when saving, since if you type a non-existing file in the text area, it will get deleted when you press the "Select" button. 

I have added a `saveFileMode` on the dialog's state so that, when this variable is true, the `fileNameText` won't get cleared for non-existing files. 

Since this is only an example, not sure if this PR is a good fit here.

Thanks!

