### PR TITLE
Fix GCC warning (by default an error) when using raygui from C++

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3147,7 +3147,7 @@ int GuiTextInputBox(Rectangle bounds, const char *title, const char *message, co
     if (secretViewActive != NULL)
     {
         if (GuiTextBox(RAYGUI_CLITERAL(Rectangle){ textBoxBounds.x, textBoxBounds.y, textBoxBounds.width - 4 - RAYGUI_TEXTINPUTBOX_HEIGHT, textBoxBounds.height }, 
-            ((*secretViewActive == 1) || textEditMode)? text : "****************", textMaxSize, textEditMode)) textEditMode = !textEditMode;
+            ((*secretViewActive == 1) || textEditMode)? text : (char *) "****************", textMaxSize, textEditMode)) textEditMode = !textEditMode;
 
         *secretViewActive = GuiToggle(RAYGUI_CLITERAL(Rectangle){ textBoxBounds.x + textBoxBounds.width - RAYGUI_TEXTINPUTBOX_HEIGHT, textBoxBounds.y, RAYGUI_TEXTINPUTBOX_HEIGHT, RAYGUI_TEXTINPUTBOX_HEIGHT }, (*secretViewActive == 1)? "#44#" : "#45#", *secretViewActive);
     }


### PR DESCRIPTION
fixes #181 

Currently, when compiling under C++ using GCC 11, the following warning is generated
```
raygui.h: In function ‘int GuiTextInputBox(Rectangle, const char*, const char*, const char*, char*, int, int*)’:
raygui.h:3150:55: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
 3150 |             ((*secretViewActive == 1) || textEditMode)? text : "****************", textMaxSize, textEditMode)) textEditMode = !textEditMode;
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                       |
      |                                                       const char*
```
it looks like GCC promotes this to an error by default. It compiles fine if I pass -fpermissive.

I believe the cause of this issue is a difference between C and C++
In C, string literals have the type char*, which is why the compiler generates no warning then (but writing to them is undefined behavior)
In C++, they have the type const char*
Casting the constness away should work as a fix, as it is basically what C does by default, and is safe to do as there is no way the function writes to the string later.