### PR TITLE
Mac dynlib build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ mv src/raygui.h src/raygui.c
 gcc -o raygui.so src/raygui.c -shared -fpic -DRAYGUI_IMPLEMENTATION -lraylib -lGL -lm -lpthread -ldl -lrt -lX11
 ```
 
+- **Mac (clang, homebrew installed raylib)**
+```
+cp src/raygui.h src/raygui.c
+brew install raylib
+gcc -o raygui.dynlib src/raygui.c -shared -fpic -DRAYGUI_IMPLEMENTATION -framework OpenGL -lm -lpthread -ldl $(pkg-config --libs --cflags raylib)
+```
+
+
 ## license
 
 raygui is licensed under an unmodified zlib/libpng license, which is an OSI-certified, BSD-like license that allows static linking with closed source software. Check [LICENSE](LICENSE) for further details.


### PR DESCRIPTION
This provides mac build instructions. Tested on OSX 12.3, on M1 hardware, with homebrew 3.4.2