### PR TITLE
Add max to GuiProgressBar

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2558,6 +2558,8 @@ float GuiSliderBar(Rectangle bounds, const char *textLeft, const char *textRight
 // Progress Bar control extended, shows current progress value
 float GuiProgressBar(Rectangle bounds, const char *textLeft, const char *textRight, float value, float minValue, float maxValue)
 {
+    if (value > maxValue) value =  maxValue // max
+    
     GuiControlState state = guiState;
 
     Rectangle progress = { bounds.x + GuiGetStyle(PROGRESSBAR, BORDER_WIDTH),


### PR DESCRIPTION
Progressbar cannot visualy overflow anymore and returning value has meaning now. I considered adding min, but have not needed it yet.