### PR TITLE
Store secret text as static variable

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3151,8 +3151,9 @@ int GuiTextInputBox(Rectangle bounds, const char *title, const char *message, co
 
     if (secretViewActive != NULL)
     {
+        static char stars[] = "****************";
         if (GuiTextBox(RAYGUI_CLITERAL(Rectangle){ textBoxBounds.x, textBoxBounds.y, textBoxBounds.width - 4 - RAYGUI_TEXTINPUTBOX_HEIGHT, textBoxBounds.height }, 
-            ((*secretViewActive == 1) || textEditMode)? text : (char *) "****************", textMaxSize, textEditMode)) textEditMode = !textEditMode;
+            ((*secretViewActive == 1) || textEditMode)? text : stars, textMaxSize, textEditMode)) textEditMode = !textEditMode;
 
         *secretViewActive = GuiToggle(RAYGUI_CLITERAL(Rectangle){ textBoxBounds.x + textBoxBounds.width - RAYGUI_TEXTINPUTBOX_HEIGHT, textBoxBounds.y, RAYGUI_TEXTINPUTBOX_HEIGHT, RAYGUI_TEXTINPUTBOX_HEIGHT }, (*secretViewActive == 1)? "#44#" : "#45#", *secretViewActive);
     }


### PR DESCRIPTION
When compiling with Zig 0.9.1, the current implementation raises this error:

```
error: expected type '[*c]u8', found '*const [16:0]u8'
note: cast discards const qualifier
```

As it does not allow casting away the const qualifier (rightly so in that case), we need to store the "********" placeholder in a writable variable. Using static storage is merely an optimization to avoid putting a "constant" buffer on the stack.