### PR TITLE
Fix for unsafe call of MeasureTextEx in GetTextWidth #203

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3740,8 +3740,8 @@ static int GetTextWidth(const char *text)
                 }
             }
         }
-
-        size = MeasureTextEx(guiFont, text + textIconOffset, (float)GuiGetStyle(DEFAULT, TEXT_SIZE), (float)GuiGetStyle(DEFAULT, TEXT_SPACING));
+        float fontSize = (float)GuiGetStyle(DEFAULT, TEXT_SIZE); // ensures guiFont is set
+        size = MeasureTextEx(guiFont, text + textIconOffset, fontSize, (float)GuiGetStyle(DEFAULT, TEXT_SPACING));
         if (textIconOffset > 0) size.x += (RAYGUI_ICON_SIZE - 4);   //ICON_TEXT_PADDING
     }
 


### PR DESCRIPTION
Fix for the issue #203, making sure a style is loaded by pulling a `GuiGetStyle` call out of the `MeasureTextEx` argument list.