### PR TITLE
add distinct icon-only buffer for internal use

### DIFF
--- a/examples/controls_test_suite/controls_test_suite.c
+++ b/examples/controls_test_suite/controls_test_suite.c
@@ -219,7 +219,7 @@ int main()
             if (showTextInputBox)
             {
                 DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(), Fade(RAYWHITE, 0.8f));
-                int result = GuiTextInputBox((Rectangle){ GetScreenWidth()/2 - 120, GetScreenHeight()/2 - 60, 240, 140 }, "Save", GuiIconText(ICON_FILE_SAVE, "Save file as..."), "Introduce a save file name", "Ok;Cancel", textInput, NULL);
+                int result = GuiTextInputBox((Rectangle){ GetScreenWidth()/2 - 120, GetScreenHeight()/2 - 60, 240, 140 }, "Save", GuiIconText(ICON_FILE_SAVE, "Save file as..."), "Ok;Cancel", textInput, 255, NULL);
 
                 if (result == 1)
                 {

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3547,20 +3547,23 @@ const char *GuiIconText(int iconId, const char *text)
     return NULL;
 #else
     static char buffer[1024] = { 0 };
-    memset(buffer, 0, 1024);
-
-    sprintf(buffer, "#%03i#", iconId);
+    static char iconBuffer[6] = {0};
 
     if (text != NULL)
     {
+        memset(buffer, 0, 1024);
+        sprintf(buffer, "#%03i#", iconId);
         for (int i = 5; i < 1024; i++)
         {
             buffer[i] = text[i - 5];
             if (text[i - 5] == '\0') break;
         }
-    }
-
     return buffer;
+    }
+    else {
+        sprintf(iconBuffer, "#%03i#", iconId&0x1ff);
+        return iconBuffer;
+    }
 #endif
 }
 


### PR DESCRIPTION
This change handles `GuiIconText` calls with only an icon on a different buffer to allow the use in `GuiSpinner` and `GuiTextInputBox` to display the icons without overwriting user text given to these widgets. It was the least intrusive way I could think of to fix the issue. It would still be a problem if one uses `GuiSpinner` or `GuiTextInputBox` with only an icon as text, but that would look not great as a user experience anyways I guess.

This change would fix #205 and fix #206 and together with the small change in the `controls_test_suite.c` to match some previous change in raygui, it makes the `controls_test_suite.c` work again. 