### PR TITLE
GuiTextBoxMulti(): Remove two potential out of bounds crashes

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2309,9 +2309,11 @@ bool GuiTextBoxMulti(Rectangle bounds, char *text, int textSize, bool editMode)
             // We get an Unicode codepoint
             int codepoint = GetCharPressed();
             int textLength = (int)strlen(text);     // Length in bytes (UTF-8 string)
+            int byteSize = 0;
+            const char *textUTF8 = CodepointToUTF8(key, &byteSize)
 
             // Introduce characters
-            if (textLength < (textSize - 1))
+            if ((textLength + byteSize) < textSize)
             {
                 if (IsKeyPressed(KEY_ENTER))
                 {
@@ -2343,7 +2345,7 @@ bool GuiTextBoxMulti(Rectangle bounds, char *text, int textSize, bool editMode)
                     {
                         // Remove latest UTF-8 unicode character introduced (n bytes)
                         int charUTF8Length = 0;
-                        while (((unsigned char)text[textLength - 1 - charUTF8Length] & 0b01000000) == 0) charUTF8Length++;
+                        while (charUTF8Length < textLength && ((unsigned char)text[textLength - 1 - charUTF8Length] & 0b01000000) == 0) charUTF8Length++;
 
                         textLength -= (charUTF8Length + 1);
                         text[textLength] = '\0';


### PR DESCRIPTION
This change will fix `GuiTextBoxMulti` to handle inserting multibyte characters at the edge of textSize and backspace of bad multibyte sequences at the beginning of the buffer without out-of-bounds writes.