### PR TITLE
Minor Fixes: Warning and errors when building for strict compilers

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3284,8 +3284,8 @@ Vector2 GuiGrid(Rectangle bounds, const char *text, float spacing, int subdivs)
         if (CheckCollisionPointRec(mousePoint, bounds))
         {
             // NOTE: Cell values must be rounded to int
-            currentCell.x = (int)((mousePoint.x - bounds.x)/spacing);
-            currentCell.y = (int)((mousePoint.y - bounds.y)/spacing);
+            currentCell.x = roundf((mousePoint.x - bounds.x)/spacing);
+            currentCell.y = roundf((mousePoint.y - bounds.y)/spacing);
         }
     }
     //--------------------------------------------------------------------
@@ -3889,11 +3889,11 @@ static const char *GetTextIcon(const char *text, int *iconId)
 }
 
 // Get text divided into lines (by line-breaks '\n')
-char **GetTextLines(char *text, int *count)
+const char **GetTextLines(const char *text, int *count)
 {
 #define RAYGUI_MAX_TEXT_LINES   128
 
-    static char *lines[RAYGUI_MAX_TEXT_LINES] = { 0 };
+    static const char *lines[RAYGUI_MAX_TEXT_LINES] = { 0 };
     memset(lines, 0, sizeof(char *));
 
     int textSize = (int)strlen(text);


### PR DESCRIPTION
Make some strings const that are never modified.
Round and don't truncate by casting (comment says it wants to round). 

These fixes help raygui work better when compiled with C++ code.

Errors usually are
```
src/raygui.h: In function ‘void GuiDrawText(const char*, Rectangle, int, Color)’:
src/raygui.h:3940:43: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
 3940 |         const char **lines = GetTextLines(text, &lineCount);
      |                                           ^~~~
      |                                           |
      |                                           const char*
src/raygui.h:3892:27: note:   initializing argument 1 of ‘char** GetTextLines(char*, int*)’
 3892 | char **GetTextLines(char *text, int *count)
      |                     ~~~~~~^~~~
src/raygui.h:3940:42: error: invalid conversion from ‘char**’ to ‘const char**’ [-fpermissive]
 3940 |         const char **lines = GetTextLines(text, &lineCount);
      |                              ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
      |                                          |
      |                                          char**
```