### PR TITLE
Minor : readability improvement in GuiCell

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3283,9 +3283,9 @@ Vector2 GuiGrid(Rectangle bounds, const char *text, float spacing, int subdivs)
     {
         if (CheckCollisionPointRec(mousePoint, bounds))
         {
-            // NOTE: Cell values must be rounded to int
-            currentCell.x = (float)((int)((mousePoint.x - bounds.x)/spacing));
-            currentCell.y = (float)((int)((mousePoint.y - bounds.y)/spacing));
+            // NOTE: Cell values must be the upper left of the cell the mouse is in
+            currentCell.x = floorf((mousePoint.x - bounds.x)/spacing));
+            currentCell.y = floorf((mousePoint.y - bounds.y)/spacing));
         }
     }
     //--------------------------------------------------------------------


### PR DESCRIPTION
Instead of double casting a value to get it to truncate, this PR uses `floorf `to get the smallest whole number for the cell. This improves readability and would work for negative cells if that ever becomes a thing.