### PR TITLE
gui_file_dialog: Fix warning

### DIFF
--- a/examples/custom_file_dialog/gui_file_dialog.h
+++ b/examples/custom_file_dialog/gui_file_dialog.h
@@ -310,7 +310,7 @@ void GuiFileDialog(GuiFileDialogState *state)
 # if defined(USE_CUSTOM_LISTVIEW_FILEINFO)
         state->filesListActive = GuiListViewFiles((Rectangle){ state->position.x + 8, state->position.y + 48 + 20, state->windowBounds.width - 16, state->windowBounds.height - 60 - 16 - 68 }, fileInfo, state->dirFiles.count, &state->itemFocused, &state->filesListScrollIndex, state->filesListActive);
 # else
-        state->filesListActive = GuiListViewEx((Rectangle){ state->windowBounds.x + 8, state->windowBounds.y + 48 + 20, state->windowBounds.width - 16, state->windowBounds.height - 60 - 16 - 68 }, dirFilesIcon, state->dirFiles.count, &state->itemFocused, &state->filesListScrollIndex, state->filesListActive);
+        state->filesListActive = GuiListViewEx((Rectangle){ state->windowBounds.x + 8, state->windowBounds.y + 48 + 20, state->windowBounds.width - 16, state->windowBounds.height - 60 - 16 - 68 }, (const char**)dirFilesIcon, state->dirFiles.count, &state->itemFocused, &state->filesListScrollIndex, state->filesListActive);
 # endif
         GuiSetStyle(LISTVIEW, TEXT_ALIGNMENT, prevTextAlignment);
         GuiSetStyle(LISTVIEW, LIST_ITEMS_HEIGHT, prevElementsHeight);


### PR DESCRIPTION
This change fixes a type warning in gui_file_dialog.h...

```
examples/custom_file_dialog/gui_file_dialog.h: In function ‘GuiFileDialog’:
examples/custom_file_dialog/gui_file_dialog.h:313:198: warning: passing argument 2 of ‘GuiListViewEx’ from incompatible pointer type [-Wincompatible-pointer-types]
  313 | dowBounds.y + 48 + 20, state->windowBounds.width - 16, state->windowBounds.height - 60 - 16 - 68 }, dirFilesIcon, state->dirFiles.count, &state->itemFocused, &state->filesListScrollIndex, state->filesListActive);
      |                                                                                                     ^~~~~~~~~~~~
      |                                                                                                     |
      |                                                                                                     char **

In file included from examples/custom_file_dialog/gui_file_dialog.h:120
examples/custom_file_dialog/../../src/raygui.h:2762:50: note: expected ‘const char **’ but argument is of type ‘char **’
 2762 | int GuiListViewEx(Rectangle bounds, const char **text, int count, int *focus, int *scrollIndex, int active)
```