### PR TITLE
Have GuiTextBox/GuiTextBoxMulti respect BORDER_WIDTH

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2166,7 +2166,7 @@ bool GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
     {
         GuiDrawRectangle(bounds, GuiGetStyle(TEXTBOX, BORDER_WIDTH), Fade(GetColor(GuiGetStyle(TEXTBOX, BORDER + (state*3))), guiAlpha), Fade(GetColor(GuiGetStyle(TEXTBOX, BASE_COLOR_DISABLED)), guiAlpha));
     }
-    else GuiDrawRectangle(bounds, 1, Fade(GetColor(GuiGetStyle(TEXTBOX, BORDER + (state*3))), guiAlpha), BLANK);
+    else GuiDrawRectangle(bounds, GuiGetStyle(TEXTBOX, BORDER_WIDTH), Fade(GetColor(GuiGetStyle(TEXTBOX, BORDER + (state*3))), guiAlpha), BLANK);
 
     if (editMode)
     {
@@ -2477,7 +2477,7 @@ bool GuiTextBoxMulti(Rectangle bounds, char *text, int textSize, bool editMode)
     {
         GuiDrawRectangle(bounds, GuiGetStyle(TEXTBOX, BORDER_WIDTH), Fade(GetColor(GuiGetStyle(TEXTBOX, BORDER + (state*3))), guiAlpha), Fade(GetColor(GuiGetStyle(TEXTBOX, BASE_COLOR_DISABLED)), guiAlpha));
     }
-    else GuiDrawRectangle(bounds, 1, Fade(GetColor(GuiGetStyle(TEXTBOX, BORDER + (state*3))), guiAlpha), BLANK);
+    else GuiDrawRectangle(bounds, GuiGetStyle(TEXTBOX, BORDER_WIDTH), Fade(GetColor(GuiGetStyle(TEXTBOX, BORDER + (state*3))), guiAlpha), BLANK);
 
     int wrapMode = 1;      // 0-No wrap, 1-Char wrap, 2-Word wrap
     Vector2 cursorPos = { textAreaBounds.x, textAreaBounds.y };


### PR DESCRIPTION
This PR allows users to control the BORDER_WIDTH of the text boxes (GuiTextBox and GuiTextBoxMulti) via GuiSetStyle.

Currently, the BORDER_WIDTH of the text boxes is taken into account when in the  'focused' or 'pressed' state. In the 'normal' state this is hard coded to 1. This change replaces the hard coded value and instead does a GuiGetStyle lookup.

By being able to control the TextBox's border we can achieve effects like -
![noborder](https://user-images.githubusercontent.com/2104033/223040644-a4092737-9332-43c2-aa20-31ded7f957b5.png)

However currently with the value hard coded to 1 you get this -
![border](https://user-images.githubusercontent.com/2104033/223040785-bbdadf12-e6b0-4069-a248-96b272f8c374.png)

If this change is counter to Raygui's design or intent please feel free to close.

Thanks for your time.
