### PR TITLE
[cmake] Update to raylib 4.5

### DIFF
--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -33,13 +33,13 @@ if(${BUILD_RAYGUI_EXAMPLES})
     set(example_dirs
         controls_test_suite
         custom_file_dialog
+        custom_sliders
         image_exporter
-        image_raw_importer
+        image_importer_raw
         portable_window
         property_list
         scroll_panel
-        text_box_selection
-        text_editor
+        style_selector
     )
 
     set(example_sources)

--- a/projects/CMake/cmake/FindRaylib.cmake
+++ b/projects/CMake/cmake/FindRaylib.cmake
@@ -1,10 +1,10 @@
-find_package(raylib 4.0.0 QUIET CONFIG)
+find_package(raylib 4.5.0 QUIET CONFIG)
 if (NOT raylib_FOUND)
     include(FetchContent)
     FetchContent_Declare(
         raylib
         GIT_REPOSITORY https://github.com/raysan5/raylib.git
-        GIT_TAG 4.2.0
+        GIT_TAG 4.5.0
     )
     FetchContent_GetProperties(raylib)
     if (NOT raylib_POPULATED) # Have we downloaded raylib yet?


### PR DESCRIPTION
This updates the cmake definition files to target raylib 4.5. Also updates the examples list to build the new examples.
