### PR TITLE
Fix error in GuiTabBar

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1566,7 +1566,7 @@ int GuiTabBar(Rectangle bounds, const char **text, int count, int *active)
             GuiSetStyle(BUTTON, BORDER_WIDTH, 1);
             GuiSetStyle(BUTTON, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
 #if defined(RAYGUI_NO_ICONS)
-            if (GuiButton(closeButtonRec, "x")) closing = i;
+            if (GuiButton(RAYGUI_CLITERAL(Rectangle){ tabBounds.x + tabBounds.width - 14 - 5, tabBounds.y + 5, 14, 14 }, "x")) closing = i;
 #else
             if (GuiButton(RAYGUI_CLITERAL(Rectangle){ tabBounds.x + tabBounds.width - 14 - 5, tabBounds.y + 5, 14, 14 }, GuiIconText(ICON_CROSS_SMALL, NULL))) closing = i;
 #endif


### PR DESCRIPTION
When ```RAYGUI_NO_ICONS``` defined, getting errors in ```GuiTabBar```. It seems this is copied from ```GuiWindowBox``` and then not edited and forgotten.