### PR TITLE
Avoid compiler warning about signedness

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1209,7 +1209,7 @@ static unsigned int guiIconScale = 1;           // Gui icon default scale (if ic
 static bool guiTooltip = false;                 // Tooltip enabled/disabled
 static const char *guiTooltipPtr = NULL;        // Tooltip string pointer (string provided by user)
 
-static unsigned int textBoxCursorIndex = 0;     // Cursor index, shared by all GuiTextBox*()
+static int textBoxCursorIndex = 0;              // Cursor index, shared by all GuiTextBox*()
 //static int blinkCursorFrameCounter = 0;       // Frame counter for cursor blinking
 static int autoCursorCooldownCounter = 0;       // Cooldown frame counter for automatic cursor movement on key-down
 static int autoCursorDelayCounter = 0;          // Delay frame counter for automatic cursor movement


### PR DESCRIPTION
Proposing to change type of ```textBoxCursorIndex``` from ```unsigned int``` to ```int``` for avoiding bunch of compiler warnings about signedness.
```textBoxCursorIndex``` is used in many arithmethic operations and comparions with int types, the only way to eliminate warnings, is either casting it to int everytime or declaring as int at the beginning. The latter is proposed.