### PR TITLE
Add an API to get the current fade color of the GUI…

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -573,6 +573,7 @@ RAYGUIAPI void GuiLock(void);                                   // Lock gui cont
 RAYGUIAPI void GuiUnlock(void);                                 // Unlock gui controls (global state)
 RAYGUIAPI bool GuiIsLocked(void);                               // Check if gui is locked (global state)
 RAYGUIAPI void GuiFade(float alpha);                            // Set gui controls alpha (global state), alpha goes from 0.0f to 1.0f
+RAYGUIAPI float GuiGetFade(void);                               // Get gui controls alpha (global state)
 RAYGUIAPI void GuiSetState(int state);                          // Set gui state (global state)
 RAYGUIAPI int GuiGetState(void);                                // Get gui state (global state)
 
@@ -1399,6 +1400,12 @@ void GuiFade(float alpha)
     else if (alpha > 1.0f) alpha = 1.0f;
 
     guiAlpha = alpha;
+}
+
+// Get gui controls alpha global state
+float GuiGetFade(void)
+{
+    return guiAlpha;
 }
 
 // Set gui state (global state)


### PR DESCRIPTION
…(for a specific reason)
The reason being, I want to set the GUI alpha to some value, and draw other things from my code using that value, too, which does not rely on raygui's GUI calls, might be a handy edition.
I believe this actually does get used during development of applications that does not use only raygui, but add their own addition of some codes, too.