### PR TITLE
Make raygui a bit more open

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1497,7 +1497,7 @@ int GuiWindowBox(Rectangle bounds, const char *title)
     GuiSetStyle(BUTTON, BORDER_WIDTH, 1);
     GuiSetStyle(BUTTON, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
 #if defined(RAYGUI_NO_ICONS)
-    clicked = GuiButton(closeButtonRec, "x");
+    result = GuiButton(closeButtonRec, "x");
 #else
     result = GuiButton(closeButtonRec, GuiIconText(ICON_CROSS_SMALL, NULL));
 #endif


### PR DESCRIPTION
Hi,
I changed the API a bit to use the "private" (static) functions in my other headers.
_(Add `RAYGUIAPI` to the "Module specific Functions")_


## Make Module specific Functions public

I had a problem when using raygui in my custom GUI-Elements Header file, I couldn't use functions like `GuiDrawRectangle` or the (global) variable `guiAlpha`.
_(This only could work when I use raygui with `#define RAYGUI_IMPLEMENTATION`, like in the [custom_sliders.c](https://github.com/raysan5/raygui/blob/master/examples/custom_sliders/custom_sliders.c) example, but my GUI components are split in different header- and cpp-files)_

## add more getters

* add `GuiGetFade`
* add `GuiSliderIsDragging`

## Little Fixes

change `clicked` to `result` in the `RAYGUI_NO_ICONS` case.
```c
#if defined(RAYGUI_NO_ICONS)
    result = GuiButton(closeButtonRec, "x");
#else
    result = GuiButton(closeButtonRec, GuiIconText(ICON_CROSS_SMALL, NULL));
#endif
```

Cast `(void*)` to `(unsigned char*)`, got some pedantic C++ errors.
```c
unsigned char *... = (unsigned char *)RAYGUI_MALLOC(...);
```
