### PR TITLE
📝 Added a note for define implemention

### DIFF
--- a/examples/animation_curve/animation_curve.c
+++ b/examples/animation_curve/animation_curve.c
@@ -18,6 +18,8 @@
 #include "raylib.h"
 
 #define RAYGUI_WINDOWBOX_STATUSBAR_HEIGHT 24
+
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/controls_test_suite/controls_test_suite.c
+++ b/examples/controls_test_suite/controls_test_suite.c
@@ -35,6 +35,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 //#define RAYGUI_CUSTOM_ICONS     // It requires providing gui_icons.h in the same directory
 //#include "gui_icons.h"          // External icons data provided, it can be generated with rGuiIcons tool

--- a/examples/custom_file_dialog/custom_file_dialog.c
+++ b/examples/custom_file_dialog/custom_file_dialog.c
@@ -17,6 +17,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/custom_sliders/custom_sliders.c
+++ b/examples/custom_sliders/custom_sliders.c
@@ -17,6 +17,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/image_exporter/image_exporter.c
+++ b/examples/image_exporter/image_exporter.c
@@ -17,6 +17,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/image_importer_raw/image_importer_raw.c
+++ b/examples/image_importer_raw/image_importer_raw.c
@@ -17,6 +17,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/portable_window/portable_window.c
+++ b/examples/portable_window/portable_window.c
@@ -17,6 +17,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/property_list/property_list.c
+++ b/examples/property_list/property_list.c
@@ -17,6 +17,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/scroll_panel/scroll_panel.c
+++ b/examples/scroll_panel/scroll_panel.c
@@ -23,6 +23,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #include "../../src/raygui.h"
 

--- a/examples/standalone/raygui_standalone.c
+++ b/examples/standalone/raygui_standalone.c
@@ -12,6 +12,7 @@
 *
 **********************************************************************************************/
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 #define RAYGUI_STANDALONE
 #include "../../src/raygui.h"

--- a/examples/style_selector/style_selector.c
+++ b/examples/style_selector/style_selector.c
@@ -17,6 +17,7 @@
 
 #include "raylib.h"
 
+// You must import raygui after this define
 #define RAYGUI_IMPLEMENTATION
 //#define RAYGUI_CUSTOM_ICONS     // It requires providing gui_icons.h in the same directory
 //#include "gui_icons.h"          // External icons data provided, it can be generated with rGuiIcons tool


### PR DESCRIPTION
There was no way to know that this must come before the `#include ...`
```c
#define RAYGUI_IMPLEMENTATION
```

So I added some note to the examples, most people will now won't need to google that. 

If this isn't needed, no worries. It was just a search and replace not much effort wasted.