### PR TITLE
Fix GuiScrollBar dragging taking slider behavior

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4878,14 +4878,16 @@ static int GuiScrollBar(Rectangle bounds, int value, int minValue, int maxValue)
 
         if (guiSliderDragging) // Keep dragging outside of bounds
         {
-            if (IsMouseButtonDown(MOUSE_LEFT_BUTTON))
+            if (IsMouseButtonDown(MOUSE_LEFT_BUTTON) &&
+                !CheckCollisionPointRec(mousePoint, arrowUpLeft) &&
+                !CheckCollisionPointRec(mousePoint, arrowDownRight))
             {
                 if (CHECK_BOUNDS_ID(bounds, guiSliderActive))
                 {
                     state = STATE_PRESSED;
 
-                    if (isVertical) value += (int)(GetMouseDelta().y/(scrollbar.height - slider.height)*valueRange);
-                    else value += (int)(GetMouseDelta().x/(scrollbar.width - slider.width)*valueRange);
+                    if (isVertical) value = (int)(((float)(mousePoint.y - scrollbar.y - slider.height/2)*valueRange)/(scrollbar.height - slider.height) + minValue);
+                    else value = (int)(((float)(mousePoint.x - scrollbar.x - slider.width/2)*valueRange)/(scrollbar.width - slider.width) + minValue);
                 }
             }
             else
@@ -4919,11 +4921,6 @@ static int GuiScrollBar(Rectangle bounds, int value, int minValue, int maxValue)
                 }
 
                 state = STATE_PRESSED;
-            }
-            else if (IsMouseButtonDown(MOUSE_LEFT_BUTTON))
-            {
-                if (isVertical) value += (int)(GetMouseDelta().y/(scrollbar.height - slider.height)*valueRange);
-                else value += (int)(GetMouseDelta().x/(scrollbar.width - slider.width)*valueRange);
             }
 
             // Keyboard control on mouse hover scrollbar


### PR DESCRIPTION
Arrows are excluded to avoid dragging the scrollbar to the beginning/end when using them

Previous behavior:

https://github.com/raysan5/raygui/assets/24270152/85433f19-d2b4-4897-9ab0-03cff84b7f06

Fixed behavior:

https://github.com/raysan5/raygui/assets/24270152/41ee75a1-b559-463f-8363-a140cb64afdf
