### PR TITLE
Solve the issue with last letter of GuiMessageBox

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3510,7 +3510,7 @@ int GuiMessageBox(Rectangle bounds, const char *title, const char *message, cons
     buttonBounds.width = (bounds.width - RAYGUI_MESSAGEBOX_BUTTON_PADDING*(buttonCount + 1))/buttonCount;
     buttonBounds.height = RAYGUI_MESSAGEBOX_BUTTON_HEIGHT;
 
-    int textWidth = GetTextWidth(message);
+    int textWidth = GetTextWidth(message) + 2;
 
     Rectangle textBounds = { 0 };
     textBounds.x = bounds.x + bounds.width/2 - textWidth/2;


### PR DESCRIPTION
Solves #315 by adding 2 to ```textWidth```.
All other controls that includes text have 2 pixel extra when measuring text width but somehow it's omitted in ```GuiMessageBox```.
