### PR TITLE
Fixed incorrect position of the GuiWindowBox closing icon with the de…

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4482,7 +4482,9 @@ static void GuiDrawText(const char *text, Rectangle bounds, int alignment, Color
                 textSizeX += RAYGUI_ICON_SIZE*guiIconScale;
 
                 // WARNING: If only icon provided, text could be pointing to EOF character: '\0'
+#if !defined(RAYGUI_NO_ICONS)
                 if ((lines[i] != NULL) && (lines[i][0] != '\0')) textSizeX += ICON_TEXT_PADDING;
+#endif
             }
 
             // Check guiTextAlign global variables


### PR DESCRIPTION
…fined RAYGUI_NO_ICONS macro.

In the absence of the added check, and disabled icons, the closing icon of the Gui Window Box was to the left of the center, although it should be strictly centered.