### PR TITLE
minor fix, removed unnecessary float cast for textOffsetY

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4685,7 +4685,7 @@ static void GuiDrawText(const char *text, Rectangle bounds, int alignment, Color
                             if ((boundsPos.x + textOffsetX + glyphWidth) > (bounds.x + bounds.width))
                             {
                                 textOffsetX = 0.0f;
-                                textOffsetY += (float)GuiGetStyle(DEFAULT, TEXT_LINE_SPACING);
+                                textOffsetY += GuiGetStyle(DEFAULT, TEXT_LINE_SPACING);
 
                                 DrawTextCodepoint(guiFont, codepoint, RAYGUI_CLITERAL(Vector2){ boundsPos.x + textOffsetX, boundsPos.y + textOffsetY }, (float)GuiGetStyle(DEFAULT, TEXT_SIZE), GuiFade(tint, guiAlpha));
                             }


### PR DESCRIPTION
textOffsetY is an int, but this addition had a float cast. This was causing issues when using raygui with implementation in zig.