### PR TITLE
Added preprocessor macro requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Provided set of icons can be reviewed and customized using [rGuiIcons](https://r
 
 ## building
 
-`raygui` is intended to be used as a portable single-file header-only library, to be directly integrated into any C/C++ codebase but some users could require a shared/dynamic version of the library, for example, to create bindings:
+`raygui` is intended to be used as a portable single-file header-only library, to be directly integrated into any C/C++ codebase (requiring the preprocessor macro `RAYGUI_IMPLEMENTATION`) but some users could require a shared/dynamic version of the library, for example, to create bindings:
 
  - **Windows (MinGW, GCC)**
 ```


### PR DESCRIPTION
This is something that isn't very clear when using the standard header method (the bindings explicitly have it in the example commands)

im not the only one who faced this issue ([example1](https://www.reddit.com/r/raylib/comments/soe1st/how_do_i_use_raygui/?rdt=62800), [example2](https://www.reddit.com/r/raylib/comments/ie5spi/using_raygui/)) and thought something like this may be useful. i wasnt sure where in the readme would be best, so i picked this spot