### PR TITLE
Implemented new function DrawSplineSegmentBezierCubic to fix example

### DIFF
--- a/examples/animation_curve/gui_curve_editor.h
+++ b/examples/animation_curve/gui_curve_editor.h
@@ -545,7 +545,7 @@ void GuiCurveEditor(GuiCurveEditorState *state, Rectangle bounds)
             const Vector2 screenC1 = (Vector2){ c1.x*innerBounds.width + innerBounds.x, innerBounds.y + innerBounds.height - c1.y*innerBounds.height };
             const Vector2 screenC2 = (Vector2){ c2.x*innerBounds.width + innerBounds.x, innerBounds.y + innerBounds.height - c2.y*innerBounds.height };
 
-            DrawLineBezierCubic(screenPos1, screenPos2, screenC1, screenC2, 1, curveColor);
+            DrawSplineSegmentBezierCubic(screenPos1, screenC1, screenC2, screenPos2, 1, curveColor);
         }
     }
 }


### PR DESCRIPTION
Hello, while testing your examples, I realized on example: "animation_curve" that you were using the function **`DrawLineBezierCubic`** which was deprecated on raylib5.0

As you explained, the ideal function to use would be **`DrawSplineSegmentBezierCubic`**
I've implemented this function and tested the program to make sure everything is working normally

Tested with : Linux Fedora 37 x86_64 GNU/Linux

I hope you find this useful and let me know if there is something else I should consider for this Pull Request.

Solves #348 

![image](https://github.com/raysan5/raygui/assets/28810331/1fa7384d-036c-47dd-8e0a-a56d2c659854)
