### PR TITLE
Fixed narrowing conversion in GuiStyleProp.

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -447,7 +447,7 @@
 typedef struct GuiStyleProp {
     unsigned short controlId;   // Control identifier
     unsigned short propertyId;  // Property identifier
-    int propertyValue;          // Property value
+    unsigned int propertyValue; // Property value
 } GuiStyleProp;
 
 /*
@@ -4844,7 +4844,7 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
             // but we need to draw all of the bad bytes using the '?' symbol moving one byte
             if (codepoint == 0x3f) codepointSize = 1; // TODO: Review not recognized codepoints size
 
-            // Wrap mode text measuring, to validate if 
+            // Wrap mode text measuring, to validate if
             // it can be drawn or a new line is required
             if (wrapMode == TEXT_WRAP_CHAR)
             {


### PR DESCRIPTION
GUI styles structure uses int, although in most cases it is an unsigned int.
This kind of conversion can cause a warning that stops compilation.
![image](https://github.com/raysan5/raygui/assets/69481867/a5d7949b-00de-4807-be4e-6f6ee7742c2a)
This happens when styles are initialized.
![image](https://github.com/raysan5/raygui/assets/69481867/97d6a375-fe51-435a-939c-29f2f42ac175)
There are similar conversions in every header style file.