### PR TITLE
avoid unused parameter wanings

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3358,6 +3358,8 @@ int GuiListViewEx(Rectangle bounds, const char **text, int count, int *scrollInd
 // Color Panel control
 int GuiColorPanel(Rectangle bounds, const char *text, Color *color)
 {
+    (void) text; // supress unused parameter warning
+
     int result = 0;
     GuiState state = guiState;
     Vector2 pickerSelector = { 0 };
@@ -3439,6 +3441,8 @@ int GuiColorPanel(Rectangle bounds, const char *text, Color *color)
 // NOTE: Returns alpha value normalized [0..1]
 int GuiColorBarAlpha(Rectangle bounds, const char *text, float *alpha)
 {
+    (void) text; // supress unused parameter warning
+
     #if !defined(RAYGUI_COLORBARALPHA_CHECKED_SIZE)
         #define RAYGUI_COLORBARALPHA_CHECKED_SIZE   10
     #endif
@@ -3529,6 +3533,8 @@ int GuiColorBarAlpha(Rectangle bounds, const char *text, float *alpha)
 //      float GuiColorBarLuminance() [BLACK->WHITE]
 int GuiColorBarHue(Rectangle bounds, const char *text, float *hue)
 {
+    (void) text; // supress unused parameter warning
+
     int result = 0;
     GuiState state = guiState;
     Rectangle selector = { (float)bounds.x - GuiGetStyle(COLORPICKER, HUEBAR_SELECTOR_OVERFLOW), (float)bounds.y + (*hue)/360.0f*bounds.height - GuiGetStyle(COLORPICKER, HUEBAR_SELECTOR_HEIGHT)/2, (float)bounds.width + GuiGetStyle(COLORPICKER, HUEBAR_SELECTOR_OVERFLOW)*2, (float)GuiGetStyle(COLORPICKER, HUEBAR_SELECTOR_HEIGHT) };
@@ -3619,6 +3625,8 @@ int GuiColorBarHue(Rectangle bounds, const char *text, float *hue)
 // NOTE: bounds define GuiColorPanel() size
 int GuiColorPicker(Rectangle bounds, const char *text, Color *color)
 {
+    (void) text; // supress unused parameter warning
+
     int result = 0;
 
     Color temp = { 200, 0, 0, 255 };
@@ -3650,6 +3658,8 @@ int GuiColorPicker(Rectangle bounds, const char *text, Color *color)
 // NOTE: bounds define GuiColorPanelHSV() size
 int GuiColorPickerHSV(Rectangle bounds, const char *text, Vector3 *colorHsv)
 {
+    (void) text; // supress unused parameter warning
+
     int result = 0;
 
     Vector3 tempHsv = { 0 };
@@ -3674,6 +3684,8 @@ int GuiColorPickerHSV(Rectangle bounds, const char *text, Vector3 *colorHsv)
 // Used by GuiColorPickerHSV()
 int GuiColorPanelHSV(Rectangle bounds, const char *text, Vector3 *colorHsv)
 {
+    (void) text; // supress unused parameter warning
+
     int result = 0;
     GuiState state = guiState;
     Vector2 pickerSelector = { 0 };
@@ -3888,6 +3900,8 @@ int GuiTextInputBox(Rectangle bounds, const char *title, const char *message, co
 // https://stackoverflow.com/questions/4435450/2d-opengl-drawing-lines-that-dont-exactly-fit-pixel-raster
 int GuiGrid(Rectangle bounds, const char *text, float spacing, int subdivs, Vector2 *mouseCell)
 {
+    (void) text; // supress unused parameter warning
+
     // Grid lines alpha amount
     #if !defined(RAYGUI_GRID_ALPHA)
         #define RAYGUI_GRID_ALPHA    0.15f
@@ -4328,6 +4342,8 @@ void GuiSetIconScale(int scale)
 // WARNING: Binary files only
 static void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize)
 {
+    (void) dataSize; // supress unused parameter warning
+
     unsigned char *fileDataPtr = (unsigned char *)fileData;
 
     char signature[5] = { 0 };


### PR DESCRIPTION
I like to compile my code with `-Werror`, which is impossible due to the unused parameters in some functions.

I see that pr #344 already tried to remove them, which was a bit too extreme.

A better solution, that doesn't change anything, is to write `(void) param;` which avoids the compiler's warning.

This is only about personal preference, without any functional effect really. But it would be really nice to be able to compile with stricter warnings.
