### PR TITLE
Fix `GuiDrawText()` sometimes drawing out of bounds

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4792,6 +4792,8 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
 #endif
         }
 
+        if (textSizeX > textBounds.width && (lines[i] != NULL) && (lines[i][0] != '\0')) textSizeX = textBounds.width;
+
         // Check guiTextAlign global variables
         switch (alignment)
         {

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4848,14 +4848,14 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
             // but we need to draw all of the bad bytes using the '?' symbol moving one byte
             if (codepoint == 0x3f) codepointSize = 1; // TODO: Review not recognized codepoints size
 
+            // Get glyph width to check if it goes out of bounds
+            if (guiFont.glyphs[index].advanceX == 0) glyphWidth = ((float)guiFont.recs[index].width*scaleFactor);
+            else glyphWidth = (float)guiFont.glyphs[index].advanceX*scaleFactor;
+
             // Wrap mode text measuring, to validate if 
             // it can be drawn or a new line is required
             if (wrapMode == TEXT_WRAP_CHAR)
             {
-                // Get glyph width to check if it goes out of bounds
-                if (guiFont.glyphs[index].advanceX == 0) glyphWidth = ((float)guiFont.recs[index].width*scaleFactor);
-                else glyphWidth = (float)guiFont.glyphs[index].advanceX*scaleFactor;
-
                 // Jump to next line if current character reach end of the box limits
                 if ((textOffsetX + glyphWidth) > textBounds.width - textBoundsWidthOffset)
                 {

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4775,6 +4775,7 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
         // Get text position depending on alignment and iconId
         //---------------------------------------------------------------------------------
         Vector2 textBoundsPosition = { textBounds.x, textBounds.y };
+        float textBoundsWidthOffset = 0.0f;
 
         // NOTE: We get text size after icon has been processed
         // WARNING: GetTextWidth() also processes text icon to get width! -> Really needed?
@@ -4823,6 +4824,7 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
             // NOTE: We consider icon height, probably different than text size
             GuiDrawIcon(iconId, (int)textBoundsPosition.x, (int)(textBounds.y + textBounds.height/2 - RAYGUI_ICON_SIZE*guiIconScale/2 + TEXT_VALIGN_PIXEL_OFFSET(textBounds.height)), guiIconScale, tint);
             textBoundsPosition.x += (RAYGUI_ICON_SIZE*guiIconScale + ICON_TEXT_PADDING);
+            textBoundsWidthOffset = (RAYGUI_ICON_SIZE*guiIconScale + ICON_TEXT_PADDING);
         }
 #endif
         // Get size in bytes of text,
@@ -4855,7 +4857,7 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
                 else glyphWidth = (float)guiFont.glyphs[index].advanceX*scaleFactor;
 
                 // Jump to next line if current character reach end of the box limits
-                if ((textOffsetX + glyphWidth) > textBounds.width)
+                if ((textOffsetX + glyphWidth) > textBounds.width - textBoundsWidthOffset)
                 {
                     textOffsetX = 0.0f;
                     textOffsetY += GuiGetStyle(DEFAULT, TEXT_LINE_SPACING);
@@ -4878,13 +4880,13 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
                 int nextSpaceIndex2 = 0;
                 float nextWordSize = GetNextSpaceWidth(lines[i] + lastSpaceIndex + 1, &nextSpaceIndex2);
 
-                if (nextWordSize > textBounds.width)
+                if (nextWordSize > textBounds.width - textBoundsWidthOffset)
                 {
                     // Considering the case the next word is longer than bounds
                     tempWrapCharMode = true;
                     wrapMode = TEXT_WRAP_CHAR;
                 }
-                else if ((textOffsetX + nextSpaceWidth) > textBounds.width)
+                else if ((textOffsetX + nextSpaceWidth) > textBounds.width - textBoundsWidthOffset)
                 {
                     textOffsetX = 0.0f;
                     textOffsetY += GuiGetStyle(DEFAULT, TEXT_LINE_SPACING);
@@ -4901,7 +4903,7 @@ static void GuiDrawText(const char *text, Rectangle textBounds, int alignment, C
                     if (wrapMode == TEXT_WRAP_NONE)
                     {
                         // Draw only required text glyphs fitting the textBounds.width
-                        if (textOffsetX <= (textBounds.width - glyphWidth))
+                        if (textOffsetX <= (textBounds.width - glyphWidth - textBoundsWidthOffset))
                         {
                             DrawTextCodepoint(guiFont, codepoint, RAYGUI_CLITERAL(Vector2){ textBoundsPosition.x + textOffsetX, textBoundsPosition.y + textOffsetY }, (float)GuiGetStyle(DEFAULT, TEXT_SIZE), GuiFade(tint, guiAlpha));
                         }


### PR DESCRIPTION
This fixes an issue where text can be drawn out of bounds if it is wider than the bounds or when an icon is used. Also, if text is center or right aligned, it can be positioned too far left, which is fixed by limiting the x position of the text to the left edge of the bounds.

Before:
![before](https://github.com/raysan5/raygui/assets/27396817/0a2e5264-fa07-4700-bac4-551f837a917f)

After:
(Since the text is wider than the bounds, alignment has no effect)
![after](https://github.com/raysan5/raygui/assets/27396817/c40b8871-c7cc-4fb9-9bd1-04d0bf4d5a65)

Alignment still behaves normally if the text is not too long:
![alignment](https://github.com/raysan5/raygui/assets/27396817/77ab6334-c728-4d43-9aae-eafe1f98d3ce)
