### PR TITLE
Commonise GuiColorPanelHSV and GuiColorPanel logic and behavior

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3362,7 +3362,7 @@ int GuiColorPanel(Rectangle bounds, const char *text, Color *color)
 
     Vector3 vcolor = { (float)color->r/255.0f, (float)color->g/255.0f, (float)color->b/255.0f };
     Vector3 hsv = ConvertRGBtoHSV(vcolor);
-    Vector3 prev_hsv = hsv; // workaround to see if GuiColorPanelHSV modifies the hsv.
+    Vector3 prevHsv = hsv; // workaround to see if GuiColorPanelHSV modifies the hsv.
 
     GuiColorPanelHSV(bounds, text, &hsv);
 
@@ -3371,7 +3371,7 @@ int GuiColorPanel(Rectangle bounds, const char *text, Color *color)
     // Thus the assignment from HSV to Color should only be made, if the HSV has a new user-entered value.
     // Otherwise GuiColorPanel would often modify it's color without user input.
     // TODO: GuiColorPanelHSV could return 1 if the slider was dragged, to simplify this check.
-    if (hsv.x != prev_hsv.x || hsv.y != prev_hsv.y || hsv.z != prev_hsv.z)
+    if (hsv.x != prevHsv.x || hsv.y != prevHsv.y || hsv.z != prevHsv.z)
     {
         Vector3 rgb = ConvertHSVtoRGB(hsv);
 

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3359,118 +3359,28 @@ int GuiListViewEx(Rectangle bounds, const char **text, int count, int *scrollInd
 int GuiColorPanel(Rectangle bounds, const char *text, Color *color)
 {
     int result = 0;
-    GuiState state = guiState;
-    Vector2 pickerSelector = { 0 };
-
-    const Color colWhite = { 255, 255, 255, 255 };
-    const Color colBlack = { 0, 0, 0, 255 };
 
     Vector3 vcolor = { (float)color->r/255.0f, (float)color->g/255.0f, (float)color->b/255.0f };
     Vector3 hsv = ConvertRGBtoHSV(vcolor);
+    Vector3 prev_hsv = hsv; // workaround to see if GuiColorPanelHSV modifies the hsv.
 
-    pickerSelector.x = bounds.x + (float)hsv.y*bounds.width;            // HSV: Saturation
-    pickerSelector.y = bounds.y + (1.0f - (float)hsv.z)*bounds.height;  // HSV: Value
+    GuiColorPanelHSV(bounds, text, &hsv);
 
-    Vector3 maxHue = { hsv.x, 1.0f, 1.0f };
-    Vector3 rgbHue = ConvertHSVtoRGB(maxHue);
-    Color maxHueCol = { (unsigned char)(255.0f*rgbHue.x),
-                      (unsigned char)(255.0f*rgbHue.y),
-                      (unsigned char)(255.0f*rgbHue.z), 255 };
-
-    // Update control
-    //--------------------------------------------------------------------
-    if ((state != STATE_DISABLED) && !guiLocked)
+    // Check if the hsv was changed, only then change the color.
+    // This is necessary, because the Color->HSV->Color conversion has precision errors.
+    // Thus the assignment from HSV to Color should only be made, if the HSV has a new user-entered value.
+    // Otherwise GuiColorPanel would often modify it's color without user input.
+    // TODO: GuiColorPanelHSV could return 1 if the slider was dragged, to simplify this check.
+    if (hsv.x != prev_hsv.x || hsv.y != prev_hsv.y || hsv.z != prev_hsv.z)
     {
-        Vector2 mousePoint = GetMousePosition();
+        Vector3 rgb = ConvertHSVtoRGB(hsv);
 
-        if (guiSliderDragging)
-        {
-            if (IsMouseButtonDown(MOUSE_LEFT_BUTTON))
-            {
-                if (CHECK_BOUNDS_ID(bounds, guiSliderActive))
-                {
-                    pickerSelector = mousePoint;
-
-                    if (pickerSelector.x < bounds.x) pickerSelector.x = bounds.x;
-                    if (pickerSelector.x > bounds.x + bounds.width) pickerSelector.x = bounds.x + bounds.width;
-                    if (pickerSelector.y < bounds.y) pickerSelector.y = bounds.y;
-                    if (pickerSelector.y > bounds.y + bounds.height) pickerSelector.y = bounds.y + bounds.height;
-
-                    // Calculate color from picker
-                    Vector2 colorPick = { pickerSelector.x - bounds.x, pickerSelector.y - bounds.y };
-
-                    colorPick.x /= (float)bounds.width;     // Get normalized value on x
-                    colorPick.y /= (float)bounds.height;    // Get normalized value on y
-
-                    hsv.y = colorPick.x;
-                    hsv.z = 1.0f - colorPick.y;
-
-                    Vector3 rgb = ConvertHSVtoRGB(hsv);
-
-                    // NOTE: Vector3ToColor() only available on raylib 1.8.1
-                    *color = RAYGUI_CLITERAL(Color){ (unsigned char)(255.0f*rgb.x),
-                                     (unsigned char)(255.0f*rgb.y),
-                                     (unsigned char)(255.0f*rgb.z),
-                                     (unsigned char)(255.0f*(float)color->a/255.0f) };
-                }
-            }
-            else
-            {
-                guiSliderDragging = false;
-                guiSliderActive = RAYGUI_CLITERAL(Rectangle){ 0, 0, 0, 0 };
-            }
-        }
-        else if (CheckCollisionPointRec(mousePoint, bounds))
-        {
-            if (IsMouseButtonDown(MOUSE_LEFT_BUTTON))
-            {
-                state = STATE_PRESSED;
-                guiSliderDragging = true;
-                guiSliderActive = bounds;
-                pickerSelector = mousePoint;
-
-                // Calculate color from picker
-                Vector2 colorPick = { pickerSelector.x - bounds.x, pickerSelector.y - bounds.y };
-
-                colorPick.x /= (float)bounds.width;     // Get normalized value on x
-                colorPick.y /= (float)bounds.height;    // Get normalized value on y
-
-                hsv.y = colorPick.x;
-                hsv.z = 1.0f - colorPick.y;
-
-                Vector3 rgb = ConvertHSVtoRGB(hsv);
-
-                // NOTE: Vector3ToColor() only available on raylib 1.8.1
-                *color = RAYGUI_CLITERAL(Color){ (unsigned char)(255.0f*rgb.x),
-                                 (unsigned char)(255.0f*rgb.y),
-                                 (unsigned char)(255.0f*rgb.z),
-                                 (unsigned char)(255.0f*(float)color->a/255.0f) };
-
-            }
-            else state = STATE_FOCUSED;
-        }
+        // NOTE: Vector3ToColor() only available on raylib 1.8.1
+        *color = RAYGUI_CLITERAL(Color){ (unsigned char)(255.0f*rgb.x),
+                            (unsigned char)(255.0f*rgb.y),
+                            (unsigned char)(255.0f*rgb.z),
+                            color->a };
     }
-    //--------------------------------------------------------------------
-
-    // Draw control
-    //--------------------------------------------------------------------
-    if (state != STATE_DISABLED)
-    {
-        DrawRectangleGradientEx(bounds, Fade(colWhite, guiAlpha), Fade(colWhite, guiAlpha), Fade(maxHueCol, guiAlpha), Fade(maxHueCol, guiAlpha));
-        DrawRectangleGradientEx(bounds, Fade(colBlack, 0), Fade(colBlack, guiAlpha), Fade(colBlack, guiAlpha), Fade(colBlack, 0));
-
-        // Draw color picker: selector
-        Rectangle selector = { pickerSelector.x - GuiGetStyle(COLORPICKER, COLOR_SELECTOR_SIZE)/2, pickerSelector.y - GuiGetStyle(COLORPICKER, COLOR_SELECTOR_SIZE)/2, (float)GuiGetStyle(COLORPICKER, COLOR_SELECTOR_SIZE), (float)GuiGetStyle(COLORPICKER, COLOR_SELECTOR_SIZE) };
-        GuiDrawRectangle(selector, 0, BLANK, colWhite);
-    }
-    else
-    {
-        DrawRectangleGradientEx(bounds, Fade(Fade(GetColor(GuiGetStyle(COLORPICKER, BASE_COLOR_DISABLED)), 0.1f), guiAlpha), Fade(Fade(colBlack, 0.6f), guiAlpha), Fade(Fade(colBlack, 0.6f), guiAlpha), Fade(Fade(GetColor(GuiGetStyle(COLORPICKER, BORDER_COLOR_DISABLED)), 0.6f), guiAlpha));
-    }
-
-    GuiDrawRectangle(bounds, GuiGetStyle(COLORPICKER, BORDER_WIDTH), GetColor(GuiGetStyle(COLORPICKER, BORDER + state*3)), BLANK);
-    //--------------------------------------------------------------------
-
     return result;
 }
 


### PR DESCRIPTION
As discussed in #366, I transferred the dragging out of bounds behavior to `GuiColorPanelHSV()` and called it inside `GuiColorPanel()`, which simplifies code quite a lot.

I **did not** modify the return values of any functions and instead used a workaround where I compare the HSV values before and after the call to `GuiColrPanelHSV()`. Thus the API is not changed.

Tested on Linux:
- `GuiColorPanel[HSV]()`
- `GuiColorPicker()`

As best as I can tell, everything behaves the same, with the addition of the new dragging out of bounds behavior.