### PR TITLE
gitignore: ignore compiled examples for Linux and OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,13 @@
 *.x86_64
 *.hex
 
+# Executables in examples (for Linux and OSX)
+# ignore all files in specific example directories
+examples/*/*
+# except for sub-directories and filenames containing a '.'
+!examples/*/*/
+!examples/*/*.*
+
 # Debug files
 *.dSYM/
 *.su


### PR DESCRIPTION
Since executables on Linux (and I believe OSX) don't have a .postfix they were not covered by the other ignores.

Note that I use the * wildcard which does not match arbitrary paths.