### PR TITLE
fixed and simplified make clean for examples on Linux

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -375,7 +375,7 @@ ifeq ($(PLATFORM),PLATFORM_DESKTOP)
 		del *.o *.exe /s
     endif
     ifeq ($(PLATFORM_OS),LINUX)
-	find -type f -executable | xargs file -i | grep -E 'x-object|x-archive|x-sharedlib|x-executable' | rev | cut -d ':' -f 2- | rev | xargs rm -fv
+		rm -f $(EXAMPLES)
     endif
     ifeq ($(PLATFORM_OS),OSX)
 		find . -type f -perm +ugo+x -delete


### PR DESCRIPTION
The previous command did not work for me (the filters came out empty after grep) and seemed overly complex.