### PR TITLE
fix floating window example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -356,7 +356,8 @@ EXAMPLES = \
     scroll_panel/scroll_panel \
     style_selector/style_selector \
     custom_sliders/custom_sliders \
-    animation_curve/animation_curve
+    animation_curve/animation_curve \
+    floating_window/floating_window \
 
 CURRENT_MAKEFILE = $(lastword $(MAKEFILE_LIST))
 

--- a/examples/floating_window/floating_window.c
+++ b/examples/floating_window/floating_window.c
@@ -1,7 +1,7 @@
 #include "raylib.h"
 
 #define RAYGUI_IMPLEMENTATION
-#include "../../raygui.h"
+#include "../../src/raygui.h"
 
 #include "../../styles/dark/style_dark.h"
 
@@ -61,9 +61,11 @@ void GuiWindowFloating(Vector2 *position, Vector2 *size, bool *minimized, bool *
         }
 
     } else if(*resizing) {
-        Vector2 mouse_delta = GetMouseDelta();
-        size->x += mouse_delta.x;
-        size->y += mouse_delta.y;
+        Vector2 mouse = GetMousePosition();
+        if (mouse.x > position->x)
+            size->x = mouse.x - position->x;
+        if (mouse.y > position->y)
+            size->y = mouse.y - position->y;
 
         // clamp window size to an arbitrary minimum value and the window size as the maximum
         if(size->x < 100) size->x = 100;


### PR DESCRIPTION
Added floating_window example to the Makefile, fixed raygui path, and made the resizing a bit better.

https://github.com/raysan5/raygui/assets/122418017/8af7c210-10ec-45dd-8ebc-0853fbaff802

https://github.com/raysan5/raygui/assets/122418017/55de07ec-3f32-4e8f-9b62-d50722eddcff

