### PR TITLE
fix typo in raygui.h

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -26,7 +26,7 @@
 *   NOTES:
 *       - WARNING: GuiLoadStyle() and GuiLoadStyle{Custom}() functions, allocate memory for
 *         font atlas recs and glyphs, freeing that memory is (usually) up to the user,
-*         no unload function is explicitly provided... but note that GuiLoadStyleDefaulf() unloads
+*         no unload function is explicitly provided... but note that GuiLoadStyleDefault() unloads
 *         by default any previously loaded font (texture, recs, glyphs).
 *       - Global UI alpha (guiAlpha) is applied inside GuiDrawRectangle() and GuiDrawText() functions
 *


### PR DESCRIPTION
Documentation in raygui.h mentions method `GuiLoadStyleDefaulf` which likely should have been `GuiLoadStyleDefault`.