### PR TITLE
Fix division by zero in GuiScrollBar function

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -5173,7 +5173,9 @@ static int GuiScrollBar(Rectangle bounds, int value, int minValue, int maxValue)
     if (value > maxValue) value = maxValue;
     if (value < minValue) value = minValue;
 
-    const int valueRange = maxValue - minValue;
+    int valueRange = maxValue - minValue;
+    if (valueRange <= 0) valueRange = 1;
+
     int sliderSize = GuiGetStyle(SCROLLBAR, SCROLL_SLIDER_SIZE);
     if (sliderSize < 1) sliderSize = 1;  // TODO: Consider a minimum slider size
 


### PR DESCRIPTION
When trying to use the floating window example, I got several times some crashes when expanding the window size.  It's caused in the GuiScrollBar function, when the maxValue is equal to the minValue (I don't know if this case is intended in the first place). Because valueRange variable is maxValue minus minValue, then it is equal to 0, and triggers a crash later, when we use it in division (division by 0).

I'm not sure if it's the best fix, maybe minValue == maxValue is not indentend in the first place and we should fix this problem earlier?