### PR TITLE
Fix icon padding adjustment in `GetTextWidth`

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4699,7 +4699,7 @@ static int GetTextWidth(const char *text)
             }
         }
 
-        if (textIconOffset > 0) textSize.x += (RAYGUI_ICON_SIZE - ICON_TEXT_PADDING);
+        if (textIconOffset > 0) textSize.x += (RAYGUI_ICON_SIZE + ICON_TEXT_PADDING);
     }
 
     return (int)textSize.x;


### PR DESCRIPTION
This fixes some issues, especially when using `GuiIconText` with `GuiGroupBox`. Thank you!