### PR TITLE
Allow passing icons in GuiTabBar

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -708,7 +708,7 @@ RAYGUIAPI int GuiWindowBox(Rectangle bounds, const char *title);                
 RAYGUIAPI int GuiGroupBox(Rectangle bounds, const char *text);                                         // Group Box control with text name
 RAYGUIAPI int GuiLine(Rectangle bounds, const char *text);                                             // Line separator control, could contain text
 RAYGUIAPI int GuiPanel(Rectangle bounds, const char *text);                                            // Panel control, useful to group controls
-RAYGUIAPI int GuiTabBar(Rectangle bounds, const char **text, int count, int *active);                  // Tab Bar control, returns TAB to be closed or -1
+RAYGUIAPI int GuiTabBar(Rectangle bounds, const char **text, const int *icons, int count, int *active); // Tab Bar control, returns TAB to be closed or -1
 RAYGUIAPI int GuiScrollPanel(Rectangle bounds, const char *text, Rectangle content, Vector2 *scroll, Rectangle *view); // Scroll Panel control
 
 // Basic controls set
@@ -1703,7 +1703,7 @@ int GuiPanel(Rectangle bounds, const char *text)
 
 // Tab Bar control
 // NOTE: Using GuiToggle() for the TABS
-int GuiTabBar(Rectangle bounds, const char **text, int count, int *active)
+int GuiTabBar(Rectangle bounds, const char **text, const int *icons, int count, int *active)
 {
     #define RAYGUI_TABBAR_ITEM_WIDTH    160
 
@@ -1738,12 +1738,12 @@ int GuiTabBar(Rectangle bounds, const char **text, int count, int *active)
             if (i == (*active))
             {
                 toggle = true;
-                GuiToggle(tabBounds, GuiIconText(12, text[i]), &toggle);
+                GuiToggle(tabBounds, GuiIconText(icons[i], text[i]), &toggle);
             }
             else
             {
                 toggle = false;
-                GuiToggle(tabBounds, GuiIconText(12, text[i]), &toggle);
+                GuiToggle(tabBounds, GuiIconText(icons[i], text[i]), &toggle);
                 if (toggle) *active = i;
             }
 


### PR DESCRIPTION
Currently the icon is set to ICON_FILETYPE_IMAGE for every tab, I don't know why.
But I think it's better for the user to set his own icons