### PR TITLE
Multiline textboxes

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2469,11 +2469,15 @@ int GuiDropdownBox(Rectangle bounds, const char *text, int *active, bool editMod
     return result;   // Mouse click: result = 1
 }
 
-int GetTextTotalLines(char *text) 
+// limit = -1 -> no limit
+int GetTextTotalLines(char *text, signed int limit)
 {
 	int linesTotal = 0;
-	for (int i = 0; i < textBoxCursorIndex; i++) {
+	while(*text!='\0' && limit!=0)
+	{
 		if (text[i]=='\n') linesTotal++;
+		text++;
+		limit--;
 	}
 	return linesTotal;
 }
@@ -2730,7 +2734,7 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetLineWidth(text + lineStart) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
             if (multiline)
             {
-            	cursor.y = GetTextTotalLines(text) * GuiGetStyle(DEFAULT, TEXT_SIZE);
+            	cursor.y = GetTextTotalLines(text, textBoxCursorIndex) * GuiGetStyle(DEFAULT, TEXT_SIZE);
             	cursor.y+= textBounds.y + textBounds.height/2 - GuiGetStyle(DEFAULT, TEXT_SIZE);
             }
 

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2472,14 +2472,14 @@ int GuiDropdownBox(Rectangle bounds, const char *text, int *active, bool editMod
 // limit = -1 -> no limit
 int GetTextTotalLines(char *text, signed int limit)
 {
-	int linesTotal = 0;
-	while(*text!='\0' && limit!=0)
-	{
-		if (text[i]=='\n') linesTotal++;
-		text++;
-		limit--;
-	}
-	return linesTotal;
+    int linesTotal = 0;
+    while(*text!='\0' && limit!=0)
+    {
+        if (text[i]=='\n') linesTotal++;
+        text++;
+        limit--;
+    }
+    return linesTotal;
 }
 
 // Text Box control
@@ -2568,8 +2568,8 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
 
             int codepoint = GetCharPressed();       // Get Unicode codepoint
             int enterPressed = IsKeyPressed(KEY_ENTER);
-        	#if !defined(RAYGUI_STANDALONE)
-         	   enterPressed |= IsKeyPressedRepeat(KEY_ENTER);
+            #if !defined(RAYGUI_STANDALONE)
+                enterPressed |= IsKeyPressedRepeat(KEY_ENTER);
             #endif
 
             if (multiline && enterPressed) codepoint = (int)'\n';
@@ -2724,18 +2724,18 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             if (multiline)
             {
                 // calculate starting position of current line
-            	lineStart = textBoxCursorIndex;
-	            while (text[lineStart]!='\n'&&lineStart>=0)
+                lineStart = textBoxCursorIndex;
+                while (text[lineStart]!='\n'&&lineStart>=0)
                 {
-	            	lineStart--;
-	            }
-	            lineStart++;
-	        }
+                    lineStart--;
+                }
+                lineStart++;
+            }
             cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetLineWidth(text + lineStart) - GetLineWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
             if (multiline)
             {
-            	cursor.y = GetTextTotalLines(text, textBoxCursorIndex) * GuiGetStyle(DEFAULT, TEXT_SIZE);
-            	cursor.y+= textBounds.y + textBounds.height/2 - GuiGetStyle(DEFAULT, TEXT_SIZE);
+                cursor.y = GetTextTotalLines(text, textBoxCursorIndex) * GuiGetStyle(DEFAULT, TEXT_SIZE);
+                cursor.y+= textBounds.y + textBounds.height/2 - GuiGetStyle(DEFAULT, TEXT_SIZE);
             }
 
             // Finish text editing on ENTER or mouse click outside bounds
@@ -4767,17 +4767,17 @@ static int GetLineWidth(const char *text)
 // Get maximum text width from all lines
 static int GetTextWidth(const char *text)
 {
-	int widestLine = GetLineWidth(text);
-	while (*text!='\0')
-	{
-		if (*text=='\n')
-		{
-			int thisLineWidth = GetLineWidth(text+1);
-			if (thisLineWidth>widestLine) widestLine = thisLineWidth;
-		}
-		text++;
-	}
-	return widestLine;
+    int widestLine = GetLineWidth(text);
+    while (*text!='\0')
+    {
+        if (*text=='\n')
+        {
+            int thisLineWidth = GetLineWidth(text+1);
+            if (thisLineWidth>widestLine) widestLine = thisLineWidth;
+        }
+        text++;
+    }
+    return widestLine;
 }
 
 // Get text bounds considering control bounds

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2714,7 +2714,16 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             else mouseCursor.x = -1;
 
             // Recalculate cursor position.y depending on textBoxCursorIndex
-            cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetTextWidth(text + textIndexOffset) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
+            int lineStart = textIndexOffset;
+            if (multiline) {
+                // calculate starting position of current line
+            	lineStart = textBoxCursorIndex;
+	            while (text[lineStart]!='\n'&&lineStart>=0) {
+	            	lineStart--;
+	            }
+	            lineStart++;
+	        }
+            cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetTextWidth(text + lineStart) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
             if (multiline) {
             	cursor.y = GetTextLines(text) * GuiGetStyle(DEFAULT, TEXT_SIZE);
             	cursor.y+= textBounds.y + textBounds.height/2 - GuiGetStyle(DEFAULT, TEXT_SIZE);

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2469,7 +2469,7 @@ int GuiDropdownBox(Rectangle bounds, const char *text, int *active, bool editMod
     return result;   // Mouse click: result = 1
 }
 
-int GetTextLines(char *text) 
+int GetTextTotalLines(char *text) 
 {
 	int linesTotal = 0;
 	for (int i = 0; i < textBoxCursorIndex; i++) {
@@ -2730,7 +2730,7 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetLineWidth(text + lineStart) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
             if (multiline)
             {
-            	cursor.y = GetTextLines(text) * GuiGetStyle(DEFAULT, TEXT_SIZE);
+            	cursor.y = GetTextTotalLines(text) * GuiGetStyle(DEFAULT, TEXT_SIZE);
             	cursor.y+= textBounds.y + textBounds.height/2 - GuiGetStyle(DEFAULT, TEXT_SIZE);
             }
 

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2468,7 +2468,8 @@ int GuiDropdownBox(Rectangle bounds, const char *text, int *active, bool editMod
     return result;   // Mouse click: result = 1
 }
 
-int GetTextLines(char *text) {
+int GetTextLines(char *text) 
+{
 	int linesTotal = 0;
 	for (int i = 0; i < textBoxCursorIndex; i++) {
 		if (text[i]=='\n') linesTotal++;
@@ -2715,16 +2716,19 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
 
             // Recalculate cursor position.y depending on textBoxCursorIndex
             int lineStart = textIndexOffset;
-            if (multiline) {
+            if (multiline)
+            {
                 // calculate starting position of current line
             	lineStart = textBoxCursorIndex;
-	            while (text[lineStart]!='\n'&&lineStart>=0) {
+	            while (text[lineStart]!='\n'&&lineStart>=0)
+                {
 	            	lineStart--;
 	            }
 	            lineStart++;
 	        }
             cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetTextWidth(text + lineStart) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
-            if (multiline) {
+            if (multiline)
+            {
             	cursor.y = GetTextLines(text) * GuiGetStyle(DEFAULT, TEXT_SIZE);
             	cursor.y+= textBounds.y + textBounds.height/2 - GuiGetStyle(DEFAULT, TEXT_SIZE);
             }

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2553,7 +2553,8 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             }
 
             int codepoint = GetCharPressed();       // Get Unicode codepoint
-            if (multiline && IsKeyPressed(KEY_ENTER)) codepoint = (int)'\n';
+            int enterPressed = IsKeyPressed(KEY_ENTER) || IsKeyPressedRepeat(KEY_ENTER);
+            if (multiline && enterPressed) codepoint = (int)'\n';
 
             // Encode codepoint as UTF-8
             int codepointSize = 0;

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2553,7 +2553,11 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             }
 
             int codepoint = GetCharPressed();       // Get Unicode codepoint
-            int enterPressed = IsKeyPressed(KEY_ENTER) || IsKeyPressedRepeat(KEY_ENTER);
+            int enterPressed = IsKeyPressed(KEY_ENTER);
+        	#if !defined(RAYGUI_STANDALONE)
+         	   enterPressed |= IsKeyPressedRepeat(KEY_ENTER);
+            #endif
+
             if (multiline && enterPressed) codepoint = (int)'\n';
 
             // Encode codepoint as UTF-8

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2727,7 +2727,7 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
 	            }
 	            lineStart++;
 	        }
-            cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetTextWidth(text + lineStart) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
+            cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetLineWidth(text + lineStart) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
             if (multiline)
             {
             	cursor.y = GetTextLines(text) * GuiGetStyle(DEFAULT, TEXT_SIZE);

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2731,7 +2731,7 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
 	            }
 	            lineStart++;
 	        }
-            cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetLineWidth(text + lineStart) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
+            cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetLineWidth(text + lineStart) - GetLineWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
             if (multiline)
             {
             	cursor.y = GetTextTotalLines(text, textBoxCursorIndex) * GuiGetStyle(DEFAULT, TEXT_SIZE);

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2468,6 +2468,14 @@ int GuiDropdownBox(Rectangle bounds, const char *text, int *active, bool editMod
     return result;   // Mouse click: result = 1
 }
 
+int GetTextLines(char *text) {
+	int linesTotal = 0;
+	for (int i = 0; i < textBoxCursorIndex; i++) {
+		if (text[i]=='\n') linesTotal++;
+	}
+	return linesTotal;
+}
+
 // Text Box control
 // NOTE: Returns true on ENTER pressed (useful for data validation)
 int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
@@ -2707,7 +2715,10 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
 
             // Recalculate cursor position.y depending on textBoxCursorIndex
             cursor.x = bounds.x + GuiGetStyle(TEXTBOX, TEXT_PADDING) + GetTextWidth(text + textIndexOffset) - GetTextWidth(text + textBoxCursorIndex) + GuiGetStyle(DEFAULT, TEXT_SPACING);
-            //if (multiline) cursor.y = GetTextLines()
+            if (multiline) {
+            	cursor.y = GetTextLines(text) * GuiGetStyle(DEFAULT, TEXT_SIZE);
+            	cursor.y+= textBounds.y + textBounds.height/2 - GuiGetStyle(DEFAULT, TEXT_SIZE);
+            }
 
             // Finish text editing on ENTER or mouse click outside bounds
             if ((!multiline && IsKeyPressed(KEY_ENTER)) ||

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1484,6 +1484,7 @@ static void DrawRectangleGradientV(int posX, int posY, int width, int height, Co
 static void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize);    // Load style from memory (binary only)
 
 static int GetTextWidth(const char *text);                      // Gui get text width using gui font and style
+static int GetLineWidth(const char *text);                      // Gui get first line width using gui font and style
 static Rectangle GetTextBounds(int control, Rectangle bounds);  // Get text bounds considering control bounds
 static const char *GetTextIcon(const char *text, int *iconId);  // Get text icon if provided and move text cursor
 
@@ -4697,8 +4698,8 @@ static void GuiLoadStyleFromMemory(const unsigned char *fileData, int dataSize)
     }
 }
 
-// Gui get text width considering icon
-static int GetTextWidth(const char *text)
+// Gui get line width considering icon
+static int GetLineWidth(const char *text)
 {
     #if !defined(ICON_TEXT_PADDING)
         #define ICON_TEXT_PADDING   4
@@ -4757,6 +4758,22 @@ static int GetTextWidth(const char *text)
     }
 
     return (int)textSize.x;
+}
+
+// Get maximum text width from all lines
+static int GetTextWidth(const char *text)
+{
+	int widestLine = GetLineWidth(text);
+	while (*text!='\0')
+	{
+		if (*text=='\n')
+		{
+			int thisLineWidth = GetLineWidth(text+1);
+			if (thisLineWidth>widestLine) widestLine = thisLineWidth;
+		}
+		text++;
+	}
+	return widestLine;
 }
 
 // Get text bounds considering control bounds


### PR DESCRIPTION
changes:
- holding enter now creates multiple lines (only without RAYGUI_STANDALONE)
- cursor correctly shows up on the x axis (except for an off by one error somewhere)
- cursor is now moves on the y axis
- added `GetTextTotalLines` (with an ability to limit the amount of characters counted)
- fixed `GetTextWidth` #415

todo:
- [ ] text wrapping
- [ ] turning on multiline mode
- [ ] mouse controls
- [ ] up/down keyboard controls
- other stuff probably

testing the code:
1. change `bool multiline = false;` to `bool multiline = true;`
2. make a GuiTextBox, write some text