### PR TITLE
Support gui clipping rectangles

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -347,6 +347,7 @@ endif
 # Define all source files required
 EXAMPLES = \
     controls_test_suite/controls_test_suite \
+    clipping_controls_test_suite/clipping_controls_test_suite \
     custom_file_dialog/custom_file_dialog \
     custom_input_box/custom_input_box\
     image_exporter/image_exporter \

--- a/examples/clipping_controls_test_suite/controls_test_suite.c
+++ b/examples/clipping_controls_test_suite/controls_test_suite.c
@@ -46,6 +46,7 @@
 //  this is to test raygui operation without it. 
 //  calling GuiSetClip enables clipping 
 //  calling GuiSetClip((Rectangle){0,0,0,0});   //  disables it
+
 #define GUI_CLIP
 
 //------------------------------------------------------------------------------------
@@ -197,9 +198,10 @@ int main()
         BeginDrawing();
 
             ClearBackground(GetColor(GuiGetStyle(DEFAULT, BACKGROUND_COLOR)));
+#ifdef GUI_CLIP
             if (shouldScissor)
                 BeginScissorMode((int)clip.x, (int)clip.y, (int)clip.width, (int)clip.height);
-
+#endif
             // raygui: controls drawing
             //----------------------------------------------------------------------------------
             // Check all possible events that require GuiLock
@@ -332,10 +334,9 @@ int main()
 
 
             //----------------------------------------------------------------------------------
+#ifdef GUI_CLIP            
         if (shouldScissor)
             EndScissorMode();
-
-#ifdef GUI_CLIP
         GuiShowClip();
 #endif
         EndDrawing();

--- a/examples/clipping_controls_test_suite/controls_test_suite.c
+++ b/examples/clipping_controls_test_suite/controls_test_suite.c
@@ -1,0 +1,351 @@
+/*******************************************************************************************
+*
+*   raygui - controls test suite
+*
+*   TEST CONTROLS:
+*       - GuiDropdownBox()
+*       - GuiCheckBox()
+*       - GuiSpinner()
+*       - GuiValueBox()
+*       - GuiTextBox()
+*       - GuiButton()
+*       - GuiComboBox()
+*       - GuiListView()
+*       - GuiToggleGroup()
+*       - GuiColorPicker()
+*       - GuiSlider()
+*       - GuiSliderBar()
+*       - GuiProgressBar()
+*       - GuiColorBarAlpha()
+*       - GuiScrollPanel()
+*
+*
+*   DEPENDENCIES:
+*       raylib 4.5          - Windowing/input management and drawing
+*       raygui 3.5          - Immediate-mode GUI controls with custom styling and icons
+*
+*   COMPILATION (Windows - MinGW):
+*       gcc -o $(NAME_PART).exe $(FILE_NAME) -I../../src -lraylib -lopengl32 -lgdi32 -std=c99
+*
+*   LICENSE: zlib/libpng
+*
+*   Copyright (c) 2016-2024 Ramon Santamaria (@raysan5)
+*
+**********************************************************************************************/
+
+#include "raylib.h"
+
+//#define RAYGUI_DEBUG_RECS_BOUNDS
+//#define RAYGUI_DEBUG_TEXT_BOUNDS
+
+#define RAYGUI_IMPLEMENTATION
+//#define RAYGUI_CUSTOM_ICONS     // It requires providing gui_icons.h in the same directory
+//#include "gui_icons.h"          // External icons data provided, it can be generated with rGuiIcons tool
+#include "raygui.h"
+
+//  this is to test raygui operation without it. 
+//  calling GuiSetClip enables clipping 
+//  calling GuiSetClip((Rectangle){0,0,0,0});   //  disables it
+#define GUI_CLIP
+
+//------------------------------------------------------------------------------------
+// Program main entry point
+//------------------------------------------------------------------------------------
+int main()
+{
+    // Initialization
+    //---------------------------------------------------------------------------------------
+    const int screenWidth = 960;
+    const int screenHeight = 560;
+
+    InitWindow(screenWidth, screenHeight, "raygui - controls test suite");
+    SetExitKey(0);
+
+    // GUI controls initialization
+    //----------------------------------------------------------------------------------
+    int dropdownBox000Active = 0;
+    bool dropDown000EditMode = false;
+
+    int dropdownBox001Active = 0;
+    bool dropDown001EditMode = false;
+
+    int spinner001Value = 0;
+    bool spinnerEditMode = false;
+
+    int valueBox002Value = 0;
+    bool valueBoxEditMode = false;
+
+    char textBoxText[64] = "Text box";
+    bool textBoxEditMode = false;
+
+    char textBoxMultiText[1024] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\n\nThisisastringlongerthanexpectedwithoutspacestotestcharbreaksforthosecases,checkingifworkingasexpected.\n\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+    bool textBoxMultiEditMode = false;
+
+    int listViewScrollIndex = 0;
+    int listViewActive = -1;
+
+    int listViewExScrollIndex = 0;
+    int listViewExActive = 2;
+    int listViewExFocus = -1;
+    const char *listViewExList[8] = { "This", "is", "a", "list view", "with", "disable", "elements", "amazing!" };
+
+    Color colorPickerValue = RED;
+
+    float sliderValue = 50.0f;
+    float sliderBarValue = 60;
+    float progressValue = 0.1f;
+
+    bool forceSquaredChecked = false;
+
+    float alphaValue = 0.5f;
+
+    //int comboBoxActive = 1;
+    int visualStyleActive = 0;
+    int prevVisualStyleActive = 0;
+
+    int toggleGroupActive = 0;
+    int toggleSliderActive = 0;
+
+    Vector2 viewScroll = { 0, 0 };
+    //----------------------------------------------------------------------------------
+
+    // Custom GUI font loading
+    //Font font = LoadFontEx("fonts/rainyhearts16.ttf", 12, 0, 0);
+    //GuiSetFont(font);
+
+    bool exitWindow = false;
+    bool showMessageBox = false;
+
+    char textInput[256] = { 0 };
+    char textInputFileName[256] = { 0 };
+    bool showTextInputBox = false;
+    bool shouldScissor = false;
+    float alpha = 1.0f;
+
+    // DEBUG: Testing how those two properties affect all controls!
+    //GuiSetStyle(DEFAULT, TEXT_PADDING, 0);
+    //GuiSetStyle(DEFAULT, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
+
+    SetTargetFPS(60);
+    //--------------------------------------------------------------------------------------
+#ifdef GUI_CLIP
+    Rectangle clip = {
+        .x = 32,
+        .y = 32,
+        .width = 512,
+        .height = 400
+    };
+    GuiSetClip(clip);
+#endif
+    // Main game loop
+    while (!exitWindow)    // Detect window close button or ESC key
+    {
+        // Update
+        //----------------------------------------------------------------------------------
+        exitWindow = WindowShouldClose();
+
+        if (IsKeyPressed(KEY_ESCAPE)) showMessageBox = !showMessageBox;
+
+        if (IsKeyDown(KEY_LEFT_CONTROL) && IsKeyPressed(KEY_S)) showTextInputBox = true;
+
+        if (IsFileDropped())
+        {
+            FilePathList droppedFiles = LoadDroppedFiles();
+
+            if ((droppedFiles.count > 0) && IsFileExtension(droppedFiles.paths[0], ".rgs")) GuiLoadStyle(droppedFiles.paths[0]);
+
+            UnloadDroppedFiles(droppedFiles);    // Clear internal buffers
+        }
+
+        //alpha -= 0.002f;
+        if (alpha < 0.0f) alpha = 0.0f;
+        if (IsKeyPressed(KEY_SPACE)) alpha = 1.0f;
+
+        GuiSetAlpha(alpha);
+        //progressValue += 0.002f;
+        if (IsKeyReleased(KEY_S))
+        {
+            shouldScissor=!shouldScissor;
+        }
+#ifdef GUI_CLIP
+        if (IsKeyPressed(KEY_LEFT))
+        {
+            clip.width-=8;
+            GuiSetClip(clip);
+        }
+        else if (IsKeyPressed(KEY_RIGHT))
+        {
+            clip.width+=8;
+            GuiSetClip(clip);
+        }
+
+        if (IsKeyPressed(KEY_UP))
+        {
+            clip.height-=8;
+            GuiSetClip(clip);
+        }
+        else if (IsKeyPressed(KEY_DOWN))
+        {
+            clip.height+=8;
+            GuiSetClip(clip);
+        }
+#endif
+        //----------------------------------------------------------------------------------
+
+        // Draw
+        //----------------------------------------------------------------------------------
+        BeginDrawing();
+
+            ClearBackground(GetColor(GuiGetStyle(DEFAULT, BACKGROUND_COLOR)));
+            if (shouldScissor)
+                BeginScissorMode((int)clip.x, (int)clip.y, (int)clip.width, (int)clip.height);
+
+            // raygui: controls drawing
+            //----------------------------------------------------------------------------------
+            // Check all possible events that require GuiLock
+            if (dropDown000EditMode || dropDown001EditMode) GuiLock();
+
+            // First GUI column
+            //GuiSetStyle(CHECKBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
+            GuiCheckBox((Rectangle){ 25, 108, 15, 15 }, "FORCE CHECK!", &forceSquaredChecked);
+
+            GuiSetStyle(TEXTBOX, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
+            //GuiSetStyle(VALUEBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
+            if (GuiSpinner((Rectangle){ 25, 135, 125, 30 }, NULL, &spinner001Value, 0, 100, spinnerEditMode)) spinnerEditMode = !spinnerEditMode;
+            if (GuiValueBox((Rectangle){ 25, 175, 125, 30 }, NULL, &valueBox002Value, 0, 100, valueBoxEditMode)) valueBoxEditMode = !valueBoxEditMode;
+            GuiSetStyle(TEXTBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
+            if (GuiTextBox((Rectangle){ 25, 215, 125, 30 }, textBoxText, 64, textBoxEditMode)) textBoxEditMode = !textBoxEditMode;
+
+            GuiSetStyle(BUTTON, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
+
+            if (GuiButton((Rectangle){ 25, 255, 125, 30 }, GuiIconText(ICON_FILE_SAVE, "Save File"))) showTextInputBox = true;
+
+            GuiGroupBox((Rectangle){ 25, 310, 125, 150 }, "STATES");
+            //GuiLock();
+            GuiSetState(STATE_NORMAL); if (GuiButton((Rectangle){ 30, 320, 115, 30 }, "NORMAL")) { }
+            GuiSetState(STATE_FOCUSED); if (GuiButton((Rectangle){ 30, 355, 115, 30 }, "FOCUSED")) { }
+            GuiSetState(STATE_PRESSED); if (GuiButton((Rectangle){ 30, 390, 115, 30 }, "#15#PRESSED")) { }
+            GuiSetState(STATE_DISABLED); if (GuiButton((Rectangle){ 30, 425, 115, 30 }, "DISABLED")) { }
+            GuiSetState(STATE_NORMAL);
+            //GuiUnlock();
+
+            GuiComboBox((Rectangle){ 25, 480, 125, 30 }, "default;Jungle;Lavanda;Dark;Bluish;Cyber;Terminal", &visualStyleActive);
+
+            // NOTE: GuiDropdownBox must draw after any other control that can be covered on unfolding
+            GuiUnlock();
+            GuiSetStyle(DROPDOWNBOX, TEXT_PADDING, 4);
+            GuiSetStyle(DROPDOWNBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
+            if (GuiDropdownBox((Rectangle){ 25, 65, 125, 30 }, "#01#ONE;#02#TWO;#03#THREE;#04#FOUR", &dropdownBox001Active, dropDown001EditMode)) dropDown001EditMode = !dropDown001EditMode;
+            GuiSetStyle(DROPDOWNBOX, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
+            GuiSetStyle(DROPDOWNBOX, TEXT_PADDING, 0);
+
+            if (GuiDropdownBox((Rectangle){ 25, 25, 125, 30 }, "ONE;TWO;THREE", &dropdownBox000Active, dropDown000EditMode)) dropDown000EditMode = !dropDown000EditMode;
+
+            // Second GUI column
+            GuiListView((Rectangle){ 165, 25, 140, 124 }, "Charmander;Bulbasaur;#18#Squirtel;Pikachu;Eevee;Pidgey", &listViewScrollIndex, &listViewActive);
+            GuiListViewEx((Rectangle){ 165, 162, 140, 184 }, listViewExList, 8, &listViewExScrollIndex, &listViewExActive, &listViewExFocus);
+
+            //GuiToggle((Rectangle){ 165, 400, 140, 25 }, "#1#ONE", &toggleGroupActive);
+            GuiToggleGroup((Rectangle){ 165, 360, 140, 24 }, "#1#ONE\n#3#TWO\n#8#THREE\n#23#", &toggleGroupActive);
+            //GuiDisable();
+            GuiSetStyle(SLIDER, SLIDER_PADDING, 2);
+            GuiToggleSlider((Rectangle){ 165, 480, 140, 30 }, "ON;OFF", &toggleSliderActive);
+            GuiSetStyle(SLIDER, SLIDER_PADDING, 0);
+
+            // Third GUI column
+            GuiPanel((Rectangle){ 320, 25, 225, 140 }, "Panel Info");
+            GuiColorPicker((Rectangle){ 320, 185, 196, 192 }, NULL, &colorPickerValue);
+
+            //GuiDisable();
+            GuiSlider((Rectangle){ 355, 400, 165, 20 }, "TEST", TextFormat("%2.2f", sliderValue), &sliderValue, -50, 100);
+            GuiSliderBar((Rectangle){ 320, 430, 200, 20 }, NULL, TextFormat("%i", (int)sliderBarValue), &sliderBarValue, 0, 100);
+            
+            GuiProgressBar((Rectangle){ 320, 460, 200, 20 }, NULL, TextFormat("%i%%", (int)(progressValue*100)), &progressValue, 0.0f, 1.0f);
+            GuiEnable();
+
+            // NOTE: View rectangle could be used to perform some scissor test
+            Rectangle view = { 0 };
+            GuiScrollPanel((Rectangle){ 560, 25, 102, 354 }, NULL, (Rectangle){ 560, 25, 300, 1200 }, &viewScroll, &view);
+
+
+            Vector2 mouseCell = { 0 };
+            GuiGrid((Rectangle) { 560, 25 + 180 + 195, 100, 120 }, NULL, 20, 3, &mouseCell);
+
+            GuiColorBarAlpha((Rectangle){ 320, 490, 200, 30 }, NULL, &alphaValue);
+
+            GuiSetStyle(DEFAULT, TEXT_ALIGNMENT_VERTICAL, TEXT_ALIGN_TOP);   // WARNING: Word-wrap does not work as expected in case of no-top alignment
+            GuiSetStyle(DEFAULT, TEXT_WRAP_MODE, TEXT_WRAP_WORD);            // WARNING: If wrap mode enabled, text editing is not supported
+            if (GuiTextBox((Rectangle){ 678, 25, 258, 492 }, textBoxMultiText, 1024, textBoxMultiEditMode)) textBoxMultiEditMode = !textBoxMultiEditMode;
+            GuiSetStyle(DEFAULT, TEXT_WRAP_MODE, TEXT_WRAP_NONE);
+            GuiSetStyle(DEFAULT, TEXT_ALIGNMENT_VERTICAL, TEXT_ALIGN_MIDDLE);
+
+            GuiSetStyle(DEFAULT, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
+            GuiStatusBar((Rectangle){ 0, (float)GetScreenHeight() - 20, (float)GetScreenWidth(), 20 }, "This is a status bar");
+            GuiSetStyle(DEFAULT, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
+            //GuiSetStyle(STATUSBAR, TEXT_INDENTATION, 20);
+
+            if (showMessageBox)
+            {
+#ifdef GUI_CLIP
+                GuiSetClip((Rectangle){0,0,GetScreenWidth(),GetScreenHeight()});
+#endif
+                DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(), Fade(RAYWHITE, 0.8f));
+                int result = GuiMessageBox((Rectangle){ (float)GetScreenWidth()/2 - 125, (float)GetScreenHeight()/2 - 50, 250, 100 }, GuiIconText(ICON_EXIT, "Close Window"), "Do you really want to exit?", "Yes;No");
+
+                if ((result == 0) || (result == 2))
+                {
+#ifdef GUI_CLIP
+                    GuiSetClip(clip);
+#endif                    
+                    showMessageBox = false;
+                }
+                else if (result == 1)
+                {
+                    exitWindow = true;
+                }
+            }
+
+            if (showTextInputBox)
+            {
+#ifdef GUI_CLIP
+                GuiSetClip((Rectangle){0,0,GetScreenWidth(),GetScreenHeight()});
+#endif                
+                DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(), Fade(RAYWHITE, 0.8f));
+                int result = GuiTextInputBox((Rectangle){ (float)GetScreenWidth()/2 - 120, (float)GetScreenHeight()/2 - 60, 240, 140 }, GuiIconText(ICON_FILE_SAVE, "Save file as..."), "Introduce output file name:", "Ok;Cancel", textInput, 255, NULL);
+
+                if (result == 1)
+                {
+                    // TODO: Validate textInput value and save
+
+                    TextCopy(textInputFileName, textInput);
+                }
+
+                if ((result == 0) || (result == 1) || (result == 2))
+                {
+                    showTextInputBox = false;
+                    TextCopy(textInput, "\0");
+#ifdef GUI_CLIP
+                    GuiSetClip(clip);
+#endif                    
+                }
+            }
+
+
+            //----------------------------------------------------------------------------------
+        if (shouldScissor)
+            EndScissorMode();
+
+#ifdef GUI_CLIP
+        GuiShowClip();
+#endif
+        EndDrawing();
+        //----------------------------------------------------------------------------------
+    }
+
+    // De-Initialization
+    //--------------------------------------------------------------------------------------
+    CloseWindow();        // Close window and OpenGL context
+    //--------------------------------------------------------------------------------------
+
+    return 0;
+}

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -3203,7 +3203,6 @@ int GuiSliderPro(Rectangle bounds, const char *textLeft, const char *textRight, 
 {
     int result = 0;
     GuiState state = guiState;
-    if (GuiClip(&bounds)) return result;
 
     float temp = (maxValue - minValue)/2.0f;
     if (value == NULL) value = &temp;
@@ -3275,17 +3274,19 @@ int GuiSliderPro(Rectangle bounds, const char *textLeft, const char *textRight, 
         slider.width = sliderValue;
         if (slider.width > bounds.width) slider.width = bounds.width - 2*GuiGetStyle(SLIDER, BORDER_WIDTH);
     }
-    //--------------------------------------------------------------------
 
-    // Draw control
-    //--------------------------------------------------------------------
-    GuiDrawRectangle(bounds, GuiGetStyle(SLIDER, BORDER_WIDTH), GetColor(GuiGetStyle(SLIDER, BORDER + (state*3))), GetColor(GuiGetStyle(SLIDER, (state != STATE_DISABLED)?  BASE_COLOR_NORMAL : BASE_COLOR_DISABLED)));
+    if (!GuiClip(&bounds))
+    {
+        //--------------------------------------------------------------------
+        // Draw control
+        //--------------------------------------------------------------------
+        GuiDrawRectangle(bounds, GuiGetStyle(SLIDER, BORDER_WIDTH), GetColor(GuiGetStyle(SLIDER, BORDER + (state*3))), GetColor(GuiGetStyle(SLIDER, (state != STATE_DISABLED)?  BASE_COLOR_NORMAL : BASE_COLOR_DISABLED)));
 
-    // Draw slider internal bar (depends on state)
-    if (state == STATE_NORMAL) GuiDrawRectangle(slider, 0, BLANK, GetColor(GuiGetStyle(SLIDER, BASE_COLOR_PRESSED)));
-    else if (state == STATE_FOCUSED) GuiDrawRectangle(slider, 0, BLANK, GetColor(GuiGetStyle(SLIDER, TEXT_COLOR_FOCUSED)));
-    else if (state == STATE_PRESSED) GuiDrawRectangle(slider, 0, BLANK, GetColor(GuiGetStyle(SLIDER, TEXT_COLOR_PRESSED)));
-
+        // Draw slider internal bar (depends on state)
+        if (state == STATE_NORMAL) GuiDrawRectangle(slider, 0, BLANK, GetColor(GuiGetStyle(SLIDER, BASE_COLOR_PRESSED)));
+        else if (state == STATE_FOCUSED) GuiDrawRectangle(slider, 0, BLANK, GetColor(GuiGetStyle(SLIDER, TEXT_COLOR_FOCUSED)));
+        else if (state == STATE_PRESSED) GuiDrawRectangle(slider, 0, BLANK, GetColor(GuiGetStyle(SLIDER, TEXT_COLOR_PRESSED)));
+    }
     // Draw left/right text if provided
     if (textLeft != NULL)
     {
@@ -3330,7 +3331,6 @@ int GuiProgressBar(Rectangle bounds, const char *textLeft, const char *textRight
 {
     int result = 0;
     GuiState state = guiState;
-    if (GuiClip(&bounds)) return result;
 
     float temp = (maxValue - minValue)/2.0f;
     if (value == NULL) value = &temp;
@@ -3350,34 +3350,36 @@ int GuiProgressBar(Rectangle bounds, const char *textLeft, const char *textRight
 
     // Draw control
     //--------------------------------------------------------------------
-    if (state == STATE_DISABLED)
+    if (!GuiClip(&bounds))
     {
-        GuiDrawRectangle(bounds, GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), GetColor(GuiGetStyle(PROGRESSBAR, BORDER + (state*3))), BLANK);
-    }
-    else
-    {
-        if (*value > minValue)
+        if (state == STATE_DISABLED)
         {
-            // Draw progress bar with colored border, more visual
-            GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y, (int)progress.width + (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
-            GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y + 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height - 2 }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
-            GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y + bounds.height - 1, (int)progress.width + (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
+            GuiDrawRectangle(bounds, GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), GetColor(GuiGetStyle(PROGRESSBAR, BORDER + (state*3))), BLANK);
         }
-        else GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
-
-        if (*value >= maxValue) GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + progress.width + 1, bounds.y, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
         else
         {
-            // Draw borders not yet reached by value
-            GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + (int)progress.width + 1, bounds.y, bounds.width - (int)progress.width - 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
-            GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + (int)progress.width + 1, bounds.y + bounds.height - 1, bounds.width - (int)progress.width - 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
-            GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + bounds.width - 1, bounds.y + 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height - 2 }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
+            if (*value > minValue)
+            {
+                // Draw progress bar with colored border, more visual
+                GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y, (int)progress.width + (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
+                GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y + 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height - 2 }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
+                GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y + bounds.height - 1, (int)progress.width + (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
+            }
+            else GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x, bounds.y, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
+
+            if (*value >= maxValue) GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + progress.width + 1, bounds.y, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_FOCUSED)));
+            else
+            {
+                // Draw borders not yet reached by value
+                GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + (int)progress.width + 1, bounds.y, bounds.width - (int)progress.width - 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
+                GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + (int)progress.width + 1, bounds.y + bounds.height - 1, bounds.width - (int)progress.width - 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH) }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
+                GuiDrawRectangle(RAYGUI_CLITERAL(Rectangle){ bounds.x + bounds.width - 1, bounds.y + 1, (float)GuiGetStyle(PROGRESSBAR, BORDER_WIDTH), bounds.height - 2 }, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BORDER_COLOR_NORMAL)));
+            }
+
+            // Draw slider internal progress bar (depends on state)
+            GuiDrawRectangle(progress, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BASE_COLOR_PRESSED)));
         }
-
-        // Draw slider internal progress bar (depends on state)
-        GuiDrawRectangle(progress, 0, BLANK, GetColor(GuiGetStyle(PROGRESSBAR, BASE_COLOR_PRESSED)));
     }
-
     // Draw left/right text if provided
     if (textLeft != NULL)
     {

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1391,7 +1391,7 @@ static int textBoxCursorIndex = 0;              // Cursor index, shared by all G
 static int autoCursorCooldownCounter = 0;       // Cooldown frame counter for automatic cursor movement on key-down
 static int autoCursorDelayCounter = 0;          // Delay frame counter for automatic cursor movement
 static Rectangle guiClip = {0};                 // gui clip rectangle
-static guiClipEnabled = false;                  // gui clipping enabled ( default false )
+static bool guiClipEnabled = false;                  // gui clipping enabled ( default false )
 //----------------------------------------------------------------------------------
 // Style data array for all gui style properties (allocated on data segment by default)
 //
@@ -1594,10 +1594,10 @@ void GuiSetClip(Rectangle clip)
 //  not needed but can be useful for debug
 void GuiShowClip()
 {
-    DrawRectangle(0, 0, guiClip.x, GetScreenHeight(), (Color){255,0,255,128});
-    DrawRectangle(guiClip.x, 0, guiClip.width, guiClip.y, (Color){255,0,255,128});
-    DrawRectangle(guiClip.x+guiClip.width, 0, GetScreenWidth()-guiClip.x+guiClip.width, GetScreenHeight(), (Color){255,0,255,128});
-    DrawRectangle(guiClip.x, guiClip.y+guiClip.height, guiClip.width, GetScreenHeight()-guiClip.y+guiClip.height, (Color){255,0,255,128});
+    DrawRectangle(0, 0, guiClip.x, GetScreenHeight(), (Color){0,0,0,128});
+    DrawRectangle(guiClip.x, 0, guiClip.width, guiClip.y, (Color){0,0,0,128});
+    DrawRectangle(guiClip.x+guiClip.width, 0, GetScreenWidth()-guiClip.x+guiClip.width, GetScreenHeight(), (Color){0,0,0,128});
+    DrawRectangle(guiClip.x, guiClip.y+guiClip.height, guiClip.width, GetScreenHeight()-guiClip.y+guiClip.height, (Color){0,0,0,128});
 }
 
 //  false if rectangle isn't clipped by gui clip rectangle
@@ -1616,14 +1616,19 @@ bool GuiClip(Rectangle *p)
 bool GuiCheckCollisionPointRec(Vector2 point, Rectangle rec)
 {
     bool collision = false;
-    if ((point.x >= rec.x) && (point.x < (rec.x + rec.width)) && (point.y >= rec.y) && (point.y < (rec.y + rec.height))) collision = true;
-    if ((point.x<guiClip.x) && 
-        (point.x>guiClip.x + guiClip.width) &&
-        (point.y<guiClip.y) &&
-        (point.y>guiClip.y + guiClip.height) && 
-        (guiClipEnabled==true))
+    if (guiClipEnabled==true)
     {
-        collision = false;
+        if ((point.x>guiClip.x) && 
+            (point.x<guiClip.x + guiClip.width) &&
+            (point.y>guiClip.y) &&
+            (point.y<guiClip.y + guiClip.height)) 
+        {
+            if ((point.x >= rec.x) && (point.x < (rec.x + rec.width)) && (point.y >= rec.y) && (point.y < (rec.y + rec.height))) collision = true;
+        }
+    }
+    else 
+    {
+        if ((point.x >= rec.x) && (point.x < (rec.x + rec.width)) && (point.y >= rec.y) && (point.y < (rec.y + rec.height))) collision = true;
     }
     return collision;
 }
@@ -3490,7 +3495,6 @@ int GuiListViewEx(Rectangle bounds, const char **text, int count, int *scrollInd
     int startIndex = (scrollIndex == NULL)? 0 : *scrollIndex;
     if ((startIndex < 0) || (startIndex > (count - visibleItems))) startIndex = 0;
     int endIndex = startIndex + visibleItems;
-
     // Update control
     //--------------------------------------------------------------------
     if ((state != STATE_DISABLED) && !guiLocked && !guiControlExclusiveMode)


### PR DESCRIPTION
Included an example with a slight change to allow moving clipping window size to test controls.
NOTE if a control is partially clipped we still render unclipped, and simply clip the mouse position to allow pixel accuracy within the clipwindow. 
NOTE if text is clipped, each letter outside of the clipwindow will not be drawn, BUT x&y position still will be updated. 

