### PR TITLE
Prevent crash when passing NULL to GuiToggleSlider

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2149,7 +2149,9 @@ int GuiToggleSlider(Rectangle bounds, const char *text, int *active)
 
     // Get substrings items from text (items pointers)
     int itemCount = 0;
-    const char **items = GuiTextSplit(text, ';', &itemCount, NULL);
+    const char **items = NULL;
+
+    if (text != NULL) items = GuiTextSplit(text, ';', &itemCount, NULL);    
 
     Rectangle slider = {
         0,      // Calculated later depending on the active toggle


### PR DESCRIPTION
Later in the function there's a if text != NULL check that draws an area only if there's text passed to the function. This prevents crashing otherwise.