### PR TITLE
Fix GuiTextSplit overrunning on max split count

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -5257,7 +5257,7 @@ static const char **GuiTextSplit(const char *text, char delimiter, int *count, i
             buffer[i] = '\0';   // Set an end of string at this point
 
             counter++;
-            if (counter > RAYGUI_TEXTSPLIT_MAX_ITEMS) break;
+            if (counter >= RAYGUI_TEXTSPLIT_MAX_ITEMS) break;
         }
     }
 


### PR DESCRIPTION
When splitting text by delimiters, the index could overrun the result buffer if exceeding the maximum number of splits (default 128). Changed a > to a >= :D

As this function is used internally by various other components, it affects various components.

This did cause a real crash for me (albeit in testing)