### PR TITLE
Fix mismatch between `if defined` and `define` for `RAYGUI_LINE_MARGIN_TEXT`.

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1633,7 +1633,7 @@ int GuiGroupBox(Rectangle bounds, const char *text)
 // Line control
 int GuiLine(Rectangle bounds, const char *text)
 {
-    #if !defined(RAYGUI_LINE_ORIGIN_SIZE)
+    #if !defined(RAYGUI_LINE_MARGIN_TEXT)
         #define RAYGUI_LINE_MARGIN_TEXT  12
     #endif
     #if !defined(RAYGUI_LINE_TEXT_PADDING)


### PR DESCRIPTION
### Changes

- Make the check match the defined macro