### PR TITLE
Fix GuiTextBox handling of codepoints when deleting text and clicking with mouse

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2611,7 +2611,7 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
                     // Move backward text from cursor position
                     for (int i = textBoxCursorIndex; i < textLength; i++) text[i] = text[i + nextCodepointSize];
 
-                    textLength -= codepointSize;
+                    textLength -= nextCodepointSize;
                     if (textBoxCursorIndex > textLength) textBoxCursorIndex = textLength;
 
                     // Make sure text last character is EOL
@@ -2672,8 +2672,8 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
                         // Move backward text from cursor position
                         for (int i = (textBoxCursorIndex - prevCodepointSize); i < textLength; i++) text[i] = text[i + prevCodepointSize];
 
-                        textBoxCursorIndex -= codepointSize;
-                        textLength -= codepointSize;
+                        textBoxCursorIndex -= prevCodepointSize;
+                        textLength -= prevCodepointSize;
                     }
 
                     // Make sure text last character is EOL
@@ -2716,7 +2716,7 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
                 float widthToMouseX = 0;
                 int mouseCursorIndex = 0;
 
-                for (int i = textIndexOffset; i < textLength; i++)
+                for (int i = textIndexOffset; i < textLength; i += codepointSize)
                 {
                     codepoint = GetCodepointNext(&text[i], &codepointSize);
                     codepointIndex = GetGlyphIndex(guiFont, codepoint);


### PR DESCRIPTION
The codeblocks handling the DELETE and BACKSPACE keys used the wrong codepointSize variable (the one for the key being pressed, instead of the codepoint being deleted).

Clicking with mouse iterated through the array without respect to the codepoint size.

This PR fixes both.