### PR TITLE
GuiTextBox paste support

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2594,9 +2594,6 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
                     }
                     if (pasteLength > 0)
                     {
-                        // Make sure we are copying full codepoints only
-                        // while (pasteText[pasteLength] != 0 && ((0x80 & pasteText[pasteLength]) != 0) && ((0xc0 & pasteText[pasteLength]) ==  0x80)) --pasteLength;
-
                         // Move forward data from cursor position
                         for (int i = textLength + pasteLength; i > textBoxCursorIndex; i--) text[i] = text[i - pasteLength];
 

--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2575,9 +2575,43 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             int codepointSize = 0;
             const char *charEncoded = CodepointToUTF8(codepoint, &codepointSize);
 
+            // Handle Paste action
+            if (IsKeyPressed(KEY_V) && (IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL)))
+            {
+                const char *pasteText = GetClipboardText();
+                if (pasteText != NULL)
+                {
+                    int pasteLength = 0;
+                    int pasteCodepoint;
+                    int pasteCodepointSize;
+                    // count how many codepoints to copy, stopping at the first unwanted control character
+                    while (true)
+                    {
+                        pasteCodepoint = GetCodepointNext(pasteText + pasteLength, &pasteCodepointSize);
+                        if (textLength + pasteLength + pasteCodepointSize >= textSize) break;
+                        if (!(multiline && (pasteCodepoint == (int)'\n')) && !(pasteCodepoint >= 32)) break;
+                        pasteLength += pasteCodepointSize;
+                    }
+                    if (pasteLength > 0)
+                    {
+                        // Make sure we are copying full codepoints only
+                        // while (pasteText[pasteLength] != 0 && ((0x80 & pasteText[pasteLength]) != 0) && ((0xc0 & pasteText[pasteLength]) ==  0x80)) --pasteLength;
+
+                        // Move forward data from cursor position
+                        for (int i = textLength + pasteLength; i > textBoxCursorIndex; i--) text[i] = text[i - pasteLength];
+
+                        // Paste data in at cursor
+                        for (int i = 0; i < pasteLength; i++) text[textBoxCursorIndex + i] = pasteText[i];
+
+                        textBoxCursorIndex += pasteLength;
+                        textLength += pasteLength;
+                        text[textLength] = '\0';
+                    }
+                }
+            }
             // Add codepoint to text, at current cursor position
             // NOTE: Make sure we do not overflow buffer size
-            if (((multiline && (codepoint == (int)'\n')) || (codepoint >= 32)) && ((textLength + codepointSize) < textSize))
+            else if (((multiline && (codepoint == (int)'\n')) || (codepoint >= 32)) && ((textLength + codepointSize) < textSize))
             {
                 // Move forward data from cursor position
                 for (int i = (textLength + codepointSize); i > textBoxCursorIndex; i--) text[i] = text[i - codepointSize];


### PR DESCRIPTION
Handling paste similarly to how standard input boxes on Windows behave:

- will try to insert as much of the clipboard text as possible at the given cursor position, without overflowing the buffer
- will only add full codepoints
- will stop at any control character in the input (e.g. will only insert until a newline character in encountered, unless multiline is true - to prepare for future multiline support)

Assumes GetClipboardText() always returns either NULL or an UTF-8 encoded string (which sadly is not clearly documented, but seems to be true for at least the GLFW and SDL backends).

Tested with various extended latin characters and emojis, which all work as expected.