### PR TITLE
Fix GuiSlider not drawing handle

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4344,8 +4344,8 @@ void GuiLoadStyleDefault(void)
     // Initialize extended property values
     // NOTE: By default, extended property values are initialized to 0
     GuiSetStyle(TOGGLE, GROUP_PADDING, 2);
-    GuiSetStyle(VALUEBOX, SLIDER_WIDTH, 16);
-    GuiSetStyle(VALUEBOX, SLIDER_PADDING, 1);
+    GuiSetStyle(SLIDER, SLIDER_WIDTH, 16);
+    GuiSetStyle(SLIDER, SLIDER_PADDING, 1);
     GuiSetStyle(PROGRESSBAR, PROGRESS_PADDING, 1);
     GuiSetStyle(CHECKBOX, CHECK_PADDING, 1);
     GuiSetStyle(COMBOBOX, COMBO_BUTTON_WIDTH, 32);


### PR DESCRIPTION
Here is the change that caused this:
https://github.com/raysan5/raygui/commit/46fd886f18c6bed1017f1cd6e9db873b2816a828#diff-d01adeecbcae2a1e13b6832e327d5f84b9ec0e13aff89630006e99a24a9f2273L4304

I believe this change was accidental. 
At least I could not find an instance where the VALUEBOX, SLIDER_WIDTH style was accessed.