### PR TITLE
`custom_file_dialog`: `-Wsign-compare` warning

### DIFF
--- a/examples/custom_file_dialog/gui_window_file_dialog.h
+++ b/examples/custom_file_dialog/gui_window_file_dialog.h
@@ -358,7 +358,7 @@ void GuiWindowFileDialog(GuiWindowFileDialogState *state)
                 if (FileExists(TextFormat("%s/%s", state->dirPathText, state->fileNameText)))
                 {
                     // Select filename from list view
-                    for (int i = 0; i < state->dirFiles.count; i++)
+                    for (unsigned int i = 0; i < state->dirFiles.count; i++)
                     {
                         if (TextIsEqual(state->fileNameText, state->dirFiles.paths[i]))
                         {
@@ -435,7 +435,7 @@ static void ReloadDirectoryFiles(GuiWindowFileDialogState *state)
     for (int i = 0; i < MAX_DIRECTORY_FILES; i++) memset(dirFilesIcon[i], 0, MAX_ICON_PATH_LENGTH);
 
     // Copy paths as icon + fileNames into dirFilesIcon
-    for (int i = 0; i < state->dirFiles.count; i++)
+    for (unsigned int i = 0; i < state->dirFiles.count; i++)
     {
         if (IsPathFile(state->dirFiles.paths[i]))
         {


### PR DESCRIPTION
Compiling the `custom_file_dialog` with `-Wall -Wextra` generates this warning

![image](https://github.com/user-attachments/assets/440c9c52-f1fc-4a65-9f8a-f9423f5944a2)
