### PR TITLE
Include of raygui_icons.h

### DIFF
--- a/examples/controls_test_suite/controls_test_suite.c
+++ b/examples/controls_test_suite/controls_test_suite.c
@@ -40,7 +40,7 @@
 
 #define RAYGUI_IMPLEMENTATION
 //#define RAYGUI_CUSTOM_ICONS     // It requires providing gui_icons.h in the same directory
-//#include "gui_icons.h"          // External icons data provided, it can be generated with rGuiIcons tool
+//#include "raygui_icons.h"          // External icons data provided, it can be generated with rGuiIcons tool
 #include "../../src/raygui.h"
 
 // raygui embedded styles

--- a/examples/style_selector/style_selector.c
+++ b/examples/style_selector/style_selector.c
@@ -19,7 +19,7 @@
 
 #define RAYGUI_IMPLEMENTATION
 //#define RAYGUI_CUSTOM_ICONS     // It requires providing gui_icons.h in the same directory
-//#include "gui_icons.h"          // External icons data provided, it can be generated with rGuiIcons tool
+//#include "raygui_icons.h"          // External icons data provided, it can be generated with rGuiIcons tool
 #include "../../src/raygui.h"
 
 // raygui embedded styles


### PR DESCRIPTION
On a couple of examples, although commented out, it was looking for "gui_icons.h" versus "raygui_icons.h".  I only saw two examples of this.  This PR is to fix that typo.