### PR TITLE
Fix examples high-dpi (#506)

### DIFF
--- a/examples/animation_curve/animation_curve.c
+++ b/examples/animation_curve/animation_curve.c
@@ -49,6 +49,8 @@ int main()
     const int screenWidth = 800;
     const int screenHeight = 540;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - animation curves");
     SetTargetFPS(60);
 

--- a/examples/controls_test_suite/controls_test_suite.c
+++ b/examples/controls_test_suite/controls_test_suite.c
@@ -67,6 +67,8 @@ int main()
     const int screenWidth = 960;
     const int screenHeight = 560;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - controls test suite");
     SetExitKey(0);
 

--- a/examples/controls_test_suite/gui_value_box_float.c
+++ b/examples/controls_test_suite/gui_value_box_float.c
@@ -28,6 +28,8 @@ int main()
     const int screenWidth = 800;
     const int screenHeight = 450;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - controls test suite");
 
     float valueBoxValue = 0.0f;

--- a/examples/custom_file_dialog/custom_file_dialog.c
+++ b/examples/custom_file_dialog/custom_file_dialog.c
@@ -35,6 +35,8 @@ int main()
     int screenWidth = 800;
     int screenHeight = 560;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - custom modal dialog");
     SetExitKey(0);
 

--- a/examples/custom_input_box/custom_input_box.c
+++ b/examples/custom_input_box/custom_input_box.c
@@ -22,6 +22,8 @@ int GuiFloatBox(Rectangle bounds, const char* text, float* value, int minValue, 
 
 int main()
 {
+	SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
 	InitWindow(250, 100, "Basic calculator");
 
 	// General variables

--- a/examples/custom_sliders/custom_sliders.c
+++ b/examples/custom_sliders/custom_sliders.c
@@ -45,6 +45,8 @@ int main()
     int screenWidth = 800;
     int screenHeight = 450;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - custom sliders");
 
     float value = 0.5f;

--- a/examples/floating_window/floating_window.c
+++ b/examples/floating_window/floating_window.c
@@ -130,6 +130,8 @@ static void DrawContent(Vector2 position, Vector2 scroll) {
 }
 
 int main(void) {
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(960, 560, "raygui - floating window example");
     SetTargetFPS(60);
     GuiLoadStyleDark();

--- a/examples/image_exporter/image_exporter.c
+++ b/examples/image_exporter/image_exporter.c
@@ -30,6 +30,8 @@ int main(int argc, char *argv[])
     const int screenWidth = 800;
     const int screenHeight = 450;
     
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - image exporter");
     
     // GUI controls initialization

--- a/examples/image_importer_raw/image_importer_raw.c
+++ b/examples/image_importer_raw/image_importer_raw.c
@@ -34,6 +34,8 @@ int main()
     const int screenWidth = 800;
     const int screenHeight = 600;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - image raw importer");
     
     Texture2D texture = { 0 };

--- a/examples/portable_window/portable_window.c
+++ b/examples/portable_window/portable_window.c
@@ -30,7 +30,8 @@ int main()
     const int screenWidth = 800;
     const int screenHeight = 600;
     
-    SetConfigFlags(FLAG_WINDOW_UNDECORATED);
+    SetConfigFlags(FLAG_WINDOW_UNDECORATED | FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - portable window");
 
     // General variables

--- a/examples/property_list/property_list.c
+++ b/examples/property_list/property_list.c
@@ -37,6 +37,8 @@ int main()
     const int screenWidth = 800;
     const int screenHeight = 450;
     
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - property list");
     
     GuiDMProperty prop[] = {

--- a/examples/scroll_panel/scroll_panel.c
+++ b/examples/scroll_panel/scroll_panel.c
@@ -39,6 +39,8 @@ int main()
     const int screenWidth = 800;
     const int screenHeight = 450;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - GuiScrollPanel()");
 
     Rectangle panelRec = { 20, 40, 200, 150 };

--- a/examples/style_selector/style_selector.c
+++ b/examples/style_selector/style_selector.c
@@ -49,6 +49,8 @@ int main()
     const int screenWidth = 800;
     const int screenHeight = 480;
 
+    SetConfigFlags(FLAG_WINDOW_HIGHDPI);
+
     InitWindow(screenWidth, screenHeight, "raygui - styles selector");
     SetExitKey(0);
 


### PR DESCRIPTION
Fix [#506](https://github.com/raysan5/raygui/issues/506)

Added `SetConfigFlags(FLAG_WINDOW_HIGHDPI);` before InitWindow in all examples/*.c files. 