### PR TITLE
Fix(examples/controls_test_suite): Lock other GUI elements when dialog window is open.

### DIFF
--- a/examples/controls_test_suite/controls_test_suite.c
+++ b/examples/controls_test_suite/controls_test_suite.c
@@ -203,11 +203,12 @@ int main()
         BeginDrawing();
 
             ClearBackground(GetColor(GuiGetStyle(DEFAULT, BACKGROUND_COLOR)));
-
+            
             // raygui: controls drawing
             //----------------------------------------------------------------------------------
             // Check all possible events that require GuiLock
             if (dropDown000EditMode || dropDown001EditMode) GuiLock();
+            if (showTextInputBox) GuiLock();
 
             // First GUI column
             //GuiSetStyle(CHECKBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
@@ -236,7 +237,9 @@ int main()
             GuiComboBox((Rectangle){ 25, 480, 125, 30 }, "default;Jungle;Lavanda;Dark;Bluish;Cyber;Terminal;Candy;Cherry;Ashes;Enefete;Sunny;Amber", &visualStyleActive);
 
             // NOTE: GuiDropdownBox must draw after any other control that can be covered on unfolding
-            GuiUnlock();
+            if (dropDown000EditMode || dropDown001EditMode) GuiUnlock();
+            if (showTextInputBox) GuiLock();    // Stay locked
+
             GuiSetStyle(DROPDOWNBOX, TEXT_PADDING, 4);
             GuiSetStyle(DROPDOWNBOX, TEXT_ALIGNMENT, TEXT_ALIGN_LEFT);
             if (GuiDropdownBox((Rectangle){ 25, 65, 125, 30 }, "#01#ONE;#02#TWO;#03#THREE;#04#FOUR", &dropdownBox001Active, dropDown001EditMode)) dropDown001EditMode = !dropDown001EditMode;
@@ -300,6 +303,8 @@ int main()
 
             if (showTextInputBox)
             {
+                GuiUnlock();
+
                 DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(), Fade(RAYWHITE, 0.8f));
                 int result = GuiTextInputBox((Rectangle){ (float)GetScreenWidth()/2 - 120, (float)GetScreenHeight()/2 - 60, 240, 140 }, GuiIconText(ICON_FILE_SAVE, "Save file as..."), "Introduce output file name:", "Ok;Cancel", textInput, 255, NULL);
 


### PR DESCRIPTION
Fixes: #511

Locking the GUI prevents other controls from stealing input from the GuiTextInputBox().

It also just makes sense to lock them, since they are greyed out.