### PR TITLE
 initialize local variables prevCodepoint and prevCodepointSize 

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2692,8 +2692,8 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             {
                 int offset = textBoxCursorIndex;
                 int accCodepointSize = 0;
-                int prevCodepointSize;
-                int prevCodepoint;
+                int prevCodepointSize = 0;
+                int prevCodepoint = 0;
 
                 // Check whitespace to delete (ASCII only)
                 while (offset > 0)
@@ -2744,8 +2744,8 @@ int GuiTextBox(Rectangle bounds, char *text, int textSize, bool editMode)
             {
                 int offset = textBoxCursorIndex;
                 //int accCodepointSize = 0;
-                int prevCodepointSize;
-                int prevCodepoint;
+                int prevCodepointSize = 0;
+                int prevCodepoint = 0;
 
                 // Check whitespace to skip (ASCII only)
                 while (offset > 0)


### PR DESCRIPTION
 initialize prevCodepoint and prevCodepointSize local variables to fix the msvc warning:

```warning c4701:  Potentially uninitialized local variable 'name' used```