### PR TITLE
Fix issue #514: prevent crash with custom allocators in GuiLoadStyleDefault

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4509,8 +4509,9 @@ void GuiLoadStyleDefault(void)
     {
         // Unload previous font texture
         UnloadTexture(guiFont.texture);
-        RAYGUI_FREE(guiFont.recs);
-        RAYGUI_FREE(guiFont.glyphs);
+        // Fix issue #514: avoid crashing with custom allocators by checking NULL before free 
+        if (guiFont.recs != NULL) RAYGUI_FREE(guiFont.recs); 
+        if (guiFont.glyphs != NULL) RAYGUI_FREE(guiFont.glyphs); 
         guiFont.recs = NULL;
         guiFont.glyphs = NULL;
 


### PR DESCRIPTION
### Description

This PR fixes issue #514 where GuiLoadStyleDefault could crash when using a custom allocator.  
The problem occurs because RAYGUI_FREE was called on guiFont.recs and guiFont.glyphs without checking if the pointers were NULL.

### Changes

- Added checks before freeing pointers:

if (guiFont.recs != NULL) RAYGUI_FREE(guiFont.recs);
if (guiFont.glyphs != NULL) RAYGUI_FREE(guiFont.glyphs);
guiFont.recs = NULL;
guiFont.glyphs = NULL;

- Added a comment explaining the fix.
- Ensures compatibility with standard malloc/free as well as custom allocators.

### Testing

- Verified that with a custom allocator, the crash no longer occurs.
- Verified normal behavior with standard malloc/free.

This fix is minimal and does not change any other functionality.
