### PR TITLE
[raygui] Disable unsafe warnings on CRT scanf functions in MSVC

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -355,6 +355,7 @@
     #elif defined(USE_LIBTYPE_SHARED)
         #define RAYGUIAPI __declspec(dllimport)     // We are using the library as a Win32 shared library (.dll)
     #endif
+    #define _CRT_SECURE_NO_WARNINGS // disable unsafe warnings on scanf functions in MSVC
 #endif
 
 // Function specifiers definition


### PR DESCRIPTION
MSVC warns that fscanf, scanf, and printf are 'unsafe' functions, yet raygui uses them to load styles.
This PR adds a #define for windows that disables these warnings.
Since raygui is single header, it doesn't have a build system to put these defines into, so it is better to put it once in the header.
there is no problem with having this define for GCC or clang on windows as it will be ignored.