### PR TITLE
`GuiTooltip()` - Fix tooltip height for multiple lines and show tooltip over box in case out of screen

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -5373,16 +5373,19 @@ static void GuiTooltip(Rectangle controlRec)
         Vector2 textSize = MeasureTextEx(GuiGetFont(), guiTooltipPtr, (float)GuiGetStyle(DEFAULT, TEXT_SIZE), (float)GuiGetStyle(DEFAULT, TEXT_SPACING));
 
         if ((controlRec.x + textSize.x + 16) > GetScreenWidth()) controlRec.x -= (textSize.x + 16 - controlRec.width);
-        if ((controlRec.y + controlRec.height + textSize.y + 12) > GetScreenHeight())
-            controlRec.y -= (controlRec.height + textSize.y + 12);
 
-        GuiPanel(RAYGUI_CLITERAL(Rectangle){ controlRec.x, controlRec.y + controlRec.height + 4, textSize.x + 16, textSize.y + 8.0f }, NULL);
+        int numberOfLines;
+        GetTextLines(guiTooltipPtr, &numberOfLines);
+        if ((controlRec.y + controlRec.height + textSize.y + 4 + 8 * numberOfLines) > GetScreenHeight())
+            controlRec.y -= (controlRec.height + textSize.y + 4 + 8 * numberOfLines);
+
+        GuiPanel(RAYGUI_CLITERAL(Rectangle){ controlRec.x, controlRec.y + controlRec.height + 4, textSize.x + 16, textSize.y + 8.0f * numberOfLines }, NULL);
 
         int textPadding = GuiGetStyle(LABEL, TEXT_PADDING);
         int textAlignment = GuiGetStyle(LABEL, TEXT_ALIGNMENT);
         GuiSetStyle(LABEL, TEXT_PADDING, 0);
         GuiSetStyle(LABEL, TEXT_ALIGNMENT, TEXT_ALIGN_CENTER);
-        GuiLabel(RAYGUI_CLITERAL(Rectangle){ controlRec.x, controlRec.y + controlRec.height + 4, textSize.x + 16, textSize.y + 8.0f }, guiTooltipPtr);
+        GuiLabel(RAYGUI_CLITERAL(Rectangle){ controlRec.x, controlRec.y + controlRec.height + 4, textSize.x + 16, textSize.y + 8.0f * numberOfLines }, guiTooltipPtr);
         GuiSetStyle(LABEL, TEXT_ALIGNMENT, textAlignment);
         GuiSetStyle(LABEL, TEXT_PADDING, textPadding);
     }


### PR DESCRIPTION
- `GuiGetStyle(DEFAULT, TEXT_SIZE)` was replaced by `textSize.y` after its calculation, which causes `"a line\nanotherline"` to be displayed nicely.
- For boxes that were near the bottom edge of the screen, the tooltip could be cut off/invisible. This has been addressed as well.