### PR TITLE
Fix GuiWindowBox border rendering with custom STATUSBAR BORDER_WIDTH

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1614,13 +1614,14 @@ int GuiWindowBox(Rectangle bounds, const char *title)
     //GuiState state = guiState;
 
     int statusBarHeight = RAYGUI_WINDOWBOX_STATUSBAR_HEIGHT;
+	int statusBorderWidth = GuiGetStyle(STATUSBAR, BORDER_WIDTH);
 
     Rectangle statusBar = { bounds.x, bounds.y, bounds.width, (float)statusBarHeight };
     if (bounds.height < statusBarHeight*2.0f) bounds.height = statusBarHeight*2.0f;
 
     const float vPadding = statusBarHeight/2.0f - RAYGUI_WINDOWBOX_CLOSEBUTTON_HEIGHT/2.0f;
-    Rectangle windowPanel = { bounds.x, bounds.y + (float)statusBarHeight - 1, bounds.width, bounds.height - (float)statusBarHeight + 1 };
-    Rectangle closeButtonRec = { statusBar.x + statusBar.width - GuiGetStyle(STATUSBAR, BORDER_WIDTH) - RAYGUI_WINDOWBOX_CLOSEBUTTON_HEIGHT - vPadding,
+    Rectangle windowPanel = { bounds.x, bounds.y + (float)statusBarHeight - (float)statusBorderWidth, bounds.width, bounds.height - (float)statusBarHeight + (float)statusBorderWidth };
+    Rectangle closeButtonRec = { statusBar.x + statusBar.width - (float)statusBorderWidth - RAYGUI_WINDOWBOX_CLOSEBUTTON_HEIGHT - vPadding,
                                  statusBar.y + vPadding, RAYGUI_WINDOWBOX_CLOSEBUTTON_HEIGHT, RAYGUI_WINDOWBOX_CLOSEBUTTON_HEIGHT };
 
     // Update control
@@ -1630,8 +1631,8 @@ int GuiWindowBox(Rectangle bounds, const char *title)
 
     // Draw control
     //--------------------------------------------------------------------
-    GuiStatusBar(statusBar, title); // Draw window header as status bar
     GuiPanel(windowPanel, NULL);    // Draw window base
+    GuiStatusBar(statusBar, title); // Draw window header as status bar
 
     // Draw window close button
     int tempBorderWidth = GuiGetStyle(BUTTON, BORDER_WIDTH);


### PR DESCRIPTION
When `STATUSBAR BORDER_WIDTH` is set to a value other than 1, the window displays a visible double border between the status bar and the panel.

The proposed fix adjusts `windowPanel` rect to account for custom `STATUSBAR BORDER_WIDTH`, and draws windowPanel before statusBar for cleaner border rendering.

### Before/After
| Before | After |
|--------|-------|
| <img width="165" height="74" alt="before" src="https://github.com/user-attachments/assets/217dfbc4-86e4-48ed-a21c-7a157e164fff" /> | <img width="196" height="80" alt="after" src="https://github.com/user-attachments/assets/00e04439-a76a-4599-9cf8-8e29187e83df" /> |


