### PR TITLE
Don't double define _CRT_SECURE_NO_WARNINGS

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -357,7 +357,9 @@
     #elif defined(USE_LIBTYPE_SHARED)
         #define RAYGUIAPI __declspec(dllimport)     // Using the library as a Win32 shared library (.dll)
     #endif
-    #define _CRT_SECURE_NO_WARNINGS                 // Disable unsafe warnings on scanf() functions in MSVC
+    #if !defined(_CRT_SECURE_NO_WARNINGS)
+        #define _CRT_SECURE_NO_WARNINGS                 // Disable unsafe warnings on scanf() functions in MSVC
+    #endif
 #endif
 
 // Function specifiers definition


### PR DESCRIPTION
This PR ensures that _CRT_SECURE_NO_WARNINGS is not defined again if it is already defined.
This mostly suppresses warnings.