### PR TITLE
Fix wrongly casting a parameter as `const char**` when calling `GuiListViewEx`

### DIFF
--- a/examples/custom_file_dialog/gui_window_file_dialog.h
+++ b/examples/custom_file_dialog/gui_window_file_dialog.h
@@ -316,7 +316,7 @@ void GuiWindowFileDialog(GuiWindowFileDialogState *state)
         state->filesListActive = GuiListViewFiles((Rectangle){ state->position.x + 8, state->position.y + 48 + 20, state->windowBounds.width - 16, state->windowBounds.height - 60 - 16 - 68 }, fileInfo, state->dirFiles.count, &state->itemFocused, &state->filesListScrollIndex, state->filesListActive);
 # else
         GuiListViewEx((Rectangle){ state->windowBounds.x + 8, state->windowBounds.y + 48 + 20, state->windowBounds.width - 16, state->windowBounds.height - 60 - 16 - 68 }, 
-                      (const char**)dirFilesIcon, state->dirFiles.count, &state->filesListScrollIndex, &state->filesListActive, &state->itemFocused);
+                      (char**)dirFilesIcon, state->dirFiles.count, &state->filesListScrollIndex, &state->filesListActive, &state->itemFocused);
 # endif
         GuiSetStyle(LISTVIEW, TEXT_ALIGNMENT, prevTextAlignment);
         GuiSetStyle(LISTVIEW, LIST_ITEMS_HEIGHT, prevElementsHeight);


### PR DESCRIPTION
Fix wrongly casting a parameter as `const char**` when calling `GuiListViewEx` (the function takes a `char**`, no const needed).