### PR TITLE
Suppress MSVC C4996 warnings in implementation section

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -1096,6 +1096,11 @@ typedef enum {
 
 #if defined(RAYGUI_IMPLEMENTATION)
 
+#if defined(_MSC_VER)
+    #pragma warning(push)
+    #pragma warning(disable: 4996)  // Disable MSVC C4996 warning for standard C functions (fopen, sscanf, etc.)
+#endif
+
 #include <stdio.h>              // Required for: FILE, fopen(), fclose(), fprintf(), feof(), fscanf(), snprintf(), vsprintf() [GuiLoadStyle(), GuiLoadIcons()]
 #include <string.h>             // Required for: strlen() [GuiTextBox(), GuiValueBox()], memset(), memcpy()
 #include <stdarg.h>             // Required for: va_list, va_start(), vfprintf(), va_end() [TextFormat()]
@@ -6048,5 +6053,9 @@ static int GetCodepointNext(const char *text, int *codepointSize)
     return codepoint;
 }
 #endif      // RAYGUI_STANDALONE
+
+#if defined(_MSC_VER)
+    #pragma warning(pop)
+#endif
 
 #endif      // RAYGUI_IMPLEMENTATION


### PR DESCRIPTION
When raygui.h is included after raylib.h (the common case), MSVC emits
C4996 warnings on every fopen/sscanf call inside the implementation section:

    raygui.h(4376): warning C4996: 'fopen': This function or variable may be unsafe.
    raygui.h(4397): warning C4996: 'sscanf': This function or variable may be unsafe.
    raygui.h(4408): warning C4996: 'sscanf': This function or variable may be unsafe.

raygui already defines _CRT_SECURE_NO_WARNINGS (line 361) to prevent this,
but it has no effect when stdio.h was already pulled in by an earlier header.
MSVC's CRT decides at first include whether to mark these functions deprecated;
a later define cannot undo that.

This PR adds a #pragma warning(push/disable/pop) block around the
RAYGUI_IMPLEMENTATION section, which suppresses C4996 at the call site
regardless of include order. The suppression is scoped — it does not
leak into user code.

Tested on MSVC 19.44 (Visual Studio 2022 Build Tools).
