### PR TITLE
Export symbols on *nix when building shared libraries

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -360,6 +360,10 @@
     #if !defined(_CRT_SECURE_NO_WARNINGS)
         #define _CRT_SECURE_NO_WARNINGS                 // Disable unsafe warnings on scanf() functions in MSVC
     #endif
+#else
+    #if defined(BUILD_LIBTYPE_SHARED)
+        #define RAYGUIAPI __attribute__((visibility("default"))) // Building as a Unix shared library (.so/.dylib)
+    #endif
 #endif
 
 // Function specifiers definition


### PR DESCRIPTION
Like raylib, when raygui is built with `BUILD_LIBTYPE_SHARED`, the `visibility` of symbols tagged with `RAYGUIAPI` need to be set to `default`. This patch does that.