### PR TITLE
GuiComboBox did not set result on value changed

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -2381,6 +2381,7 @@ int GuiComboBox(Rectangle bounds, const char *text, int *active)
             {
                 *active += 1;
                 if (*active >= itemCount) *active = 0;      // Cyclic combobox
+				result = 1;
             }
 
             if (GUI_BUTTON_DOWN) state = STATE_PRESSED;


### PR DESCRIPTION
Not much to say. added result = 1; when clicked. 