### PR TITLE
Fix compilation error when RAYGUI_NO_ICONS is defined

### DIFF
--- a/src/raygui.h
+++ b/src/raygui.h
@@ -4776,6 +4776,8 @@ void GuiSetIconScale(int scale)
     if (scale >= 1) guiIconScale = scale;
 }
 
+#endif      // !RAYGUI_NO_ICONS
+
 // Get text width considering gui style and icon size (if required)
 int GuiGetTextWidth(const char *text)
 {
@@ -4837,8 +4839,6 @@ int GuiGetTextWidth(const char *text)
 
     return (int)textSize.x;
 }
-
-#endif      // !RAYGUI_NO_ICONS
 
 //----------------------------------------------------------------------------------
 // Module Internal Functions Definition


### PR DESCRIPTION
Moved `#endif // !RAYGUI_NO_ICONS` above `GuiGetTextWidth()`

The error:

```
$ gcc -o portable_window/portable_window portable_window/portable_window.c -I../src -lraylib -DRAYGUI_NO_ICONS -lm

/usr/bin/ld: /tmp/cc0BKnar.o: in function `GuiLine':
portable_window.c:(.text+0x9b2): undefined reference to `GuiGetTextWidth'
/usr/bin/ld: /tmp/cc0BKnar.o: in function `GuiLabelButton':
portable_window.c:(.text+0x27a6): undefined reference to `GuiGetTextWidth'
/usr/bin/ld: /tmp/cc0BKnar.o: in function `GuiToggleSlider':
portable_window.c:(.text+0x3448): undefined reference to `GuiGetTextWidth'
/usr/bin/ld: /tmp/cc0BKnar.o: in function `GuiCheckBox':
portable_window.c:(.text+0x35fc): undefined reference to `GuiGetTextWidth'
/usr/bin/ld: /tmp/cc0BKnar.o: in function `GuiTextBox':
portable_window.c:(.text+0x49d0): undefined reference to `GuiGetTextWidth'
/usr/bin/ld: /tmp/cc0BKnar.o:portable_window.c:(.text+0x49eb): more undefined references to `GuiGetTextWidth' follow
collect2: error: ld returned 1 exit status
```