### PR TITLE
Working MSVC build command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ gcc -o src/raygui.dll src/raygui.c -shared -DRAYGUI_IMPLEMENTATION -DBUILD_LIBTY
  - **Windows (MSVC)**
 ```
 copy src\raygui.h src\raygui.c
-cl /O2 /I../raylib/src/ /D_USRDLL /D_WINDLL /DRAYGUI_IMPLEMENTATION /DBUILD_LIBTYPE_SHARED src/raygui.c /LD /Feraygui.dll /link /LIBPATH ../raylib/build/raylib/Release/raylib.lib /subsystem:windows /machine:x64
+# For `cl` to be accessible open "Developer Command Prompt for VS 2022".
+cl /O2 /I<RELATIVE_PATH_TO_RAYLIB_INCLUDE_DIR> /D_USRDLL /D_WINDLL /DRAYGUI_IMPLEMENTATION /DBUILD_LIBTYPE_SHARED src/raygui.c /LD /Feraygui.dll /link /LIBPATH <RELATIVE_PATH_TO_raylib.lib> msvcrt.lib winmm.lib gdi32.lib user32.lib shell32.lib /subsystem:windows /machine:x64
 ```
 
  - **Linux (GCC)**


### PR DESCRIPTION
Provided msvc build command did not work, so I fixed it up to make it work, and decided to contribute :)

Hints + linking necessary dependencies on windows: msvcrt.lib winmm.lib gdi32.lib user32.lib shell32.lib.