### PR TITLE
Clearer MSVC build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ gcc -o src/raygui.dll src/raygui.c -shared -DRAYGUI_IMPLEMENTATION -DBUILD_LIBTY
 ```
 copy src\raygui.h src\raygui.c
 # For `cl` to be accessible open "Developer Command Prompt for VS 2022".
-cl /O2 /I<RELATIVE_PATH_TO_RAYLIB_INCLUDE_DIR> /D_USRDLL /D_WINDLL /DRAYGUI_IMPLEMENTATION /DBUILD_LIBTYPE_SHARED src/raygui.c /LD /Feraygui.dll /link /LIBPATH <RELATIVE_PATH_TO_raylib.lib> msvcrt.lib winmm.lib gdi32.lib user32.lib shell32.lib /subsystem:windows /machine:x64
+cl /O2 /I<RELATIVE_PATH_TO_RAYLIB_INCLUDE_DIR> /D_USRDLL /D_WINDLL /DRAYGUI_IMPLEMENTATION /DBUILD_LIBTYPE_SHARED src/raygui.c /LD /Feraygui.dll /link /LIBPATH <RELATIVE_PATH_TO_RAYLIB_IMPORT_LIBRARY> msvcrt.lib winmm.lib gdi32.lib user32.lib shell32.lib /subsystem:windows /machine:x64
+
+# Example:
+# cl /O2 /I../raylib-6_0_win64_msvc16/include /D_USRDLL /D_WINDLL /DRAYGUI_IMPLEMENTATION /DBUILD_LIBTYPE_SHARED src/raygui.c /LD /Feraygui.dll /link /LIBPATH ../raylib-6_0_win64_msvc16/lib/raylibdll.lib msvcrt.lib winmm.lib gdi32.lib user32.lib shell32.lib /subsystem:windows /machine:x64
 ```
 
  - **Linux (GCC)**


### PR DESCRIPTION
More clarification. MSVC binary build of Raylib provided by official github repository (which is what user will mostly want to link raygui against) actually contains both static and dynamic libraries. And `.lib` file in there is not so called "import library", it's actually a full static library, so linking against it in this case is incorrect. `.lib` extension is confusing, because it could be both a static library and an import library. 

So, user actually wants to link with `raylibdll.lib` and not `raylib.lib`.

In my previous PR I incorrectly hint user into linking `.lib` which can be correct if `.lib` is in fact import library, but in most cases that would not be the case. That is why I am adding this clarification.

<RELATIVE_PATH_TO_raylib.lib> --> <RELATIVE_PATH_TO_RAYLIB_IMPORT_LIBRARY>