### PR TITLE
Add build.zig.zon to raygui

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,19 @@
+.{
+    .name = .raygui,
+    .version = "4.0.0",
+    .minimum_zig_version = "0.16.0",
+
+    .fingerprint = 0x6ef335682ef70c01,
+
+    .dependencies = .{},
+
+    // Only src/ (raygui.h) is consumed by downstream builds (raylib's
+    // C backend includes it directly; raylib_zig vendors its own copy).
+    // Everything else (examples/styles/docs/icons/images/logo/projects)
+    // stays in the repo but is excluded from what `zig fetch` materializes
+    // and hashes, keeping the local package cache lean.
+    .paths = .{
+        "src",
+        "LICENSE",
+    },
+}


### PR DESCRIPTION
context: 
zig users can already use raygui just by fetching the source then use whatever they like from it

reason for build.zig.zon:
the .paths declaration in .zon gates what gets copied to the zig-pkg folder. if .paths are not properly gated to whats actually needed, all the additional files like .pngs etc. will get duped into the zig-pkg fodler which leads to unnecessary disk usage.

i am aware this is not really a raygui issue, but as a zig user i would be really happy if this was solved in any way.

related https://github.com/david-vanderson/dvui/pull/975